### PR TITLE
Add sanitize callback to comment meta registration

### DIFF
--- a/helpers/helper-translation-discussion.php
+++ b/helpers/helper-translation-discussion.php
@@ -41,14 +41,14 @@ class Helper_Translation_Discussion extends GP_Translation_Helper {
 
 		register_post_type( self::POST_TYPE, $post_type_args );
 
-		// TODO Add sanitize_callback
 		register_meta(
 			'comment',
 			'translation_id',
 			array(
-				'description'  => 'Translation that was displayed when the comment was posted',
-				'single'       => true,
-				'show_in_rest' => true,
+				'description'       => 'Translation that was displayed when the comment was posted',
+				'single'            => true,
+				'show_in_rest'      => true,
+				'sanitize_callback' => array( $this, 'sanitize_translation_id' ),
 			)
 		);
 
@@ -223,6 +223,13 @@ class Helper_Translation_Discussion extends GP_Translation_Helper {
 			$comment_locale = 'unknown';
 		}
 		return $comment_locale;
+	}
+
+	public function sanitize_translation_id( $translation_id ) {
+		if ( ! is_numeric( $translation_id ) ) {
+			wp_die( 'Invalid translation ID' );
+		}
+		return $translation_id;
 	}
 }
 

--- a/helpers/helper-translation-discussion.php
+++ b/helpers/helper-translation-discussion.php
@@ -220,7 +220,7 @@ class Helper_Translation_Discussion extends GP_Translation_Helper {
 		$all_gp_locales = array_keys( $gp_locales->locales );
 
 		if ( ! in_array( $comment_locale, $all_gp_locales ) ) {
-			$comment_locale = 'unknown';
+			$comment_locale = '';
 		}
 		return $comment_locale;
 	}
@@ -261,7 +261,7 @@ function gth_discussion_callback( $comment, $args, $depth ) {
 		}
 		echo '<time datetime=" ' . get_comment_time( 'c' ) . '">' . $time . '</time>';
 		?>
-		<?php if ( $comment_locale && $comment_locale !== 'unknown' ) : ?>
+		<?php if ( $comment_locale ) : ?>
 			<div class="comment-locale">Locale:
 				<?php if ( ! $current_locale ) : ?>
 					<a href="<?php echo esc_attr( $comment_locale . '/default' ); ?>"><?php echo esc_html( $comment_locale ); ?></a>

--- a/helpers/helper-translation-discussion.php
+++ b/helpers/helper-translation-discussion.php
@@ -52,14 +52,14 @@ class Helper_Translation_Discussion extends GP_Translation_Helper {
 			)
 		);
 
-		// TODO Add sanitize_callback
 		register_meta(
 			'comment',
 			'locale',
 			array(
-				'description'  => 'Locale slug associated with a string comment',
-				'single'       => true,
-				'show_in_rest' => true,
+				'description'       => 'Locale slug associated with a string comment',
+				'single'            => true,
+				'show_in_rest'      => true,
+				'sanitize_callback' => array( $this, 'sanitize_comment_locale' ),
 			)
 		);
 
@@ -214,6 +214,16 @@ class Helper_Translation_Discussion extends GP_Translation_Helper {
 		return $comment_topic;
 
 	}
+
+	public function sanitize_comment_locale( $comment_locale ) {
+		$gp_locales     = new GP_Locales();
+		$all_gp_locales = array_keys( $gp_locales->locales );
+
+		if ( ! in_array( $comment_locale, $all_gp_locales ) ) {
+			$comment_locale = 'unknown';
+		}
+		return $comment_locale;
+	}
 }
 
 function gth_discussion_get_original_id_from_post( $post_id ) {
@@ -244,7 +254,7 @@ function gth_discussion_callback( $comment, $args, $depth ) {
 		}
 		echo '<time datetime=" ' . get_comment_time( 'c' ) . '">' . $time . '</time>';
 		?>
-		<?php if ( $comment_locale ) : ?>
+		<?php if ( $comment_locale && $comment_locale !== 'unknown' ) : ?>
 			<div class="comment-locale">Locale:
 				<?php if ( ! $current_locale ) : ?>
 					<a href="<?php echo esc_attr( $comment_locale . '/default' ); ?>"><?php echo esc_html( $comment_locale ); ?></a>

--- a/helpers/helper-translation-discussion.php
+++ b/helpers/helper-translation-discussion.php
@@ -227,7 +227,9 @@ class Helper_Translation_Discussion extends GP_Translation_Helper {
 
 	public function sanitize_translation_id( $translation_id ) {
 		if ( ! is_numeric( $translation_id ) ) {
-			wp_die( 'Invalid translation ID' );
+			if ( $translation_id > 0 && ! GP::$translation->get( $translation_id ) ) {
+				wp_die( 'Invalid translation ID' );
+			}
 		}
 		return $translation_id;
 	}


### PR DESCRIPTION
This pull request addresses the issue of commenters posting invalid or non-existent locales or transaction IDs along with their comments. I have added the the 'sanitize_callback' function that checks this and handles invalid inputs.