### PR TITLE
Add asterisk to show that the Topic dropdown is required

### DIFF
--- a/helpers-assets/templates/translation-discussion-comments.php
+++ b/helpers-assets/templates/translation-discussion-comments.php
@@ -53,7 +53,7 @@
 			}
 
 			echo '<p class="comment-form-topic">
-					<label for="comment_topic">Topic </label>
+					<label for="comment_topic">Topic <span class="required" aria-hidden="true">*</span></label>
 					<select required name="comment_topic" id="comment_topic">
 						<option value="">Select topic</option>
 						<option value="typo">Typo in the English text</option>


### PR DESCRIPTION
I added an asterisk (*) to show that the comment topic field is required before a comment can be submitted. See screenshot below;
<img width="761" alt="Screenshot 2022-01-17 at 16 07 00" src="https://user-images.githubusercontent.com/2834132/149794215-e332c951-107e-4416-8dde-0fd3db9985e1.png">

