### PR TITLE
Remove broken 'in reply to' link

### DIFF
--- a/helpers/helper-translation-discussion.php
+++ b/helpers/helper-translation-discussion.php
@@ -278,14 +278,6 @@ function gth_discussion_callback( $comment, $args, $depth ) {
 		<footer>
 			<div class="comment-author vcard">
 				<?php
-				if ( $comment->comment_parent ) {
-					printf(
-						'<a href="%1$s">%2$s</a>',
-						esc_url( get_comment_link( $comment->comment_parent ) ),
-						sprintf( __( 'in reply to %s' ), get_comment_author( $comment->comment_parent ) )
-					);
-				}
-
 				add_filter(
 					'comment_reply_link',
 					function( $link, $args, $comment, $post ) {


### PR DESCRIPTION
Comments are already shown in a threaded view so there's no need to have the 'in reply to' link which is also broken.

![image](https://user-images.githubusercontent.com/2834132/150868815-6ed454c7-047a-4220-b834-ce2ad6294df5.png)
