### PR TITLE
Generate a valid original permalink for the custom post type

### DIFF
--- a/helpers/helper-translation-discussion.php
+++ b/helpers/helper-translation-discussion.php
@@ -87,22 +87,32 @@ class Helper_Translation_Discussion extends GP_Translation_Helper {
 			return $post_link;
 		}
 
-		if ( ! isset( $cache[ $post->ID ] ) ) {
-			$original_id = self::get_original_from_post_id( $post->ID );
-			if ( $original_id ) {
-				$original = GP::$original->get( $original_id );
-				if ( $original ) {
-					$project = GP::$project->get( $original->project_id );
-					if ( $project ) {
-						$post_link = GP_Route_Translation_Helpers::get_permalink( $project->path, $original_id );
-					}
-				}
-			}
-			$cache[ $post->ID ] = $post_link;
-		} else {
-			$post_link = $cache[ $post->ID ];
+		if ( isset( $cache[ $post->ID ] ) ) {
+			return $cache[ $post->ID ];
 		}
-		return $post_link;
+
+		// Cache the error case and overwrite it later if we succeed.
+		$cache[ $post->ID ] = $post_link;
+
+		$original_id = self::get_original_from_post_id( $post->ID );
+		if ( ! $original_id ) {
+			return $cache[ $post->ID ];
+		}
+
+		$original = GP::$original->get( $original_id );
+		if ( ! $original ) {
+			return $cache[ $post->ID ];
+		}
+
+		$project = GP::$project->get( $original->project_id );
+		if ( ! $project ) {
+			return $cache[ $post->ID ];
+		}
+
+		// We were able to gather all information, let's put it in the cache.
+		$cache[ $post->ID ] = GP_Route_Translation_Helpers::get_permalink( $project->path, $original_id );
+
+		return $cache[ $post->ID ];
 	}
 
 	public function comment_moderation( $approved, $commentdata ) {

--- a/helpers/helper-translation-discussion.php
+++ b/helpers/helper-translation-discussion.php
@@ -82,12 +82,14 @@ class Helper_Translation_Discussion extends GP_Translation_Helper {
 
 	public function rewrite_original_post_type_permalink( $post_link, $post ) {
 		static $cache = array();
-		$params = array();
-		wp_parse_str( wp_parse_url( $post_link, PHP_URL_QUERY ), $params );
-		if ( isset( $params[ self::POST_TYPE ] ) ) {
-			$post_id = intval( $params[ self::POST_TYPE ] );
-			$original_id = self::get_original_from_post_id( $post_id );
-			if ( $original_id && ! isset( $cache[ $original_id ] ) ) {
+
+		if ( self::POST_TYPE !== $post->post_type ) {
+			return $post_link;
+		}
+
+		if ( ! isset( $cache[ $post->ID ] ) ) {
+			$original_id = self::get_original_from_post_id( $post->ID );
+			if ( $original_id ) {
 				$original = GP::$original->get( $original_id );
 				if ( $original ) {
 					$project = GP::$project->get( $original->project_id );
@@ -95,10 +97,10 @@ class Helper_Translation_Discussion extends GP_Translation_Helper {
 						$post_link = GP_Route_Translation_Helpers::get_permalink( $project->path, $original_id );
 					}
 				}
-				$cache[ $original_id ] = $post_link;
-			} else {
-				$post_link = $cache[ $original_id ];
 			}
+			$cache[ $post->ID ] = $post_link;
+		} else {
+			$post_link = $cache[ $post->ID ];
 		}
 		return $post_link;
 	}

--- a/includes/class-gp-route-translation-helpers.php
+++ b/includes/class-gp-route-translation-helpers.php
@@ -171,7 +171,7 @@ class GP_Route_Translation_Helpers extends GP_Route {
 			$this->die_with_404();
 		}
 
-		$permalink = $this->get_permalink($project->path, $original_id, $set_slug, $locale_slug);
+		$permalink = self::get_permalink($project->path, $original_id, $set_slug, $locale_slug);
 
 		$args = array(
 			'project_id'     => $project->id,
@@ -216,7 +216,7 @@ class GP_Route_Translation_Helpers extends GP_Route {
 		return $comment_locales;
 	}
 
-	public function get_permalink( $project_path, $original_id, $set_slug = null, $locale_slug = null ){
+	public static function get_permalink( $project_path, $original_id, $set_slug = null, $locale_slug = null ){
 		$permalink = '/projects/' . $project_path . '/' . $original_id;
 		if ( $set_slug && $locale_slug ) {
 			$permalink .= '/' . $locale_slug . '/' . $set_slug;

--- a/includes/class-gp-route-translation-helpers.php
+++ b/includes/class-gp-route-translation-helpers.php
@@ -171,7 +171,7 @@ class GP_Route_Translation_Helpers extends GP_Route {
 			$this->die_with_404();
 		}
 
-		$permalink = self::get_permalink($project->path, $original_id, $set_slug, $locale_slug);
+		$permalink = self::get_permalink( $project->path, $original_id, $set_slug, $locale_slug );
 
 		$args = array(
 			'project_id'     => $project->id,

--- a/includes/class-gp-translation-helpers.php
+++ b/includes/class-gp-translation-helpers.php
@@ -25,8 +25,7 @@ class GP_Translation_Helpers {
 		add_filter(
 			'gp_translation_row_template_more_links',
 			function( $more_links, $project, $locale, $translation_set, $translation ) {
-				$route_translation_helpers = new GP_Route_Translation_Helpers();
-				$permalink = $route_translation_helpers->get_permalink($project->path, $translation->original_id, $translation_set->slug, $translation_set->locale);
+				$permalink = GP_Route_Translation_Helpers::get_permalink( $project->path, $translation->original_id, $translation_set->slug, $translation_set->locale );
 
 				$more_links['discussion'] = '<a href="' . esc_url( $permalink ) . '">Discussion</a>';
 


### PR DESCRIPTION
Before this, the permalinks for the comments page (visible in wp-admin/edit-comments.php or permalinks generated on the comment page) had the format `/gth_original/123` instead of the page for the original (`/projects/$project_path/$original_id/`).

This implements a filter that makes WordPress generate the correct permalinks so that it's now possible to view the comments from wp-admin in the context of the original page.

### Screenshots
Before:
<img width="406" alt="Screenshot 2022-01-25 at 13 19 41" src="https://user-images.githubusercontent.com/203408/150976058-5d4c23e6-3a55-4758-9316-4c7ea8b7fffe.png">


After:
<img width="411" alt="Screenshot 2022-01-25 at 13 19 29" src="https://user-images.githubusercontent.com/203408/150976086-dfa858c3-0640-45c1-a433-296fe4df0811.png">

