### PR TITLE
Fix broken new discussion

### DIFF
--- a/helpers/helper-translation-discussion.php
+++ b/helpers/helper-translation-discussion.php
@@ -292,7 +292,7 @@ class Helper_Translation_Discussion extends GP_Translation_Helper {
 					array(
 						'post_type'      => self::POST_TYPE,
 						'tax_input'      => array(
-							self::LINK_TAXONOMY => array( $original_id ),
+							self::LINK_TAXONOMY => array( strval( $original_id ) ),
 						),
 						'post_status'    => self::POST_STATUS,
 						'post_author'    => 0,


### PR DESCRIPTION
#15 broke starting a new discussion on a original that didn't have a shadow post. See the report at https://make.wordpress.org/polyglots/2022/02/08/call-for-early-testers-glotpress-feedback-feature/#comment-293842

This attempts to fix this.