### PR TITLE
Set translation status

### DIFF
--- a/js/reject-feedback.js
+++ b/js/reject-feedback.js
@@ -51,6 +51,7 @@
 
 		if ( ! comment.trim().length && ! rejectReason.length ) {
 			// No need to send the feedback.
+			$gp.editor.set_status( button, status );
 			return;
 		}
 


### PR DESCRIPTION
Add the line `$gp.editor.set_status( button, status );` so that when the `Reject` button is clicked, the translation status can be set even though rejection reasons and rejection comment are both empty. 
This also prevents posting empty rejection feedback and comments via AJAX.