### PR TITLE
Fix null/undefined translation_id

### DIFF
--- a/helpers-assets/js/translation-discussion.js
+++ b/helpers-assets/js/translation-discussion.js
@@ -32,6 +32,10 @@ jQuery( function( $ ) {
 		e.preventDefault();
 		e.stopImmediatePropagation();
 
+		if ( ! formdata.meta.translation_id ) {
+			formdata.meta.translation_id = 0;
+		}
+
 		if ( formdata.meta.locale ) {
 			/**
 			 * Set the locale to an empty string if option selected has value 'typo' or 'context'


### PR DESCRIPTION
Posting a comment on a discussion page should be added to the top of the comments without a page reload. 

However, it was discovered that when there's no current translation(which means translation_id is null or undefined), a page reload (after posting a comment) is required for the comment to be displayed - this has been fixed in this PR.

In this PR, if the `translation_id` sent via ajax when posting comment is null or undefined, we set it to `0`