### PR TITLE
Improve the original display

### DIFF
--- a/includes/class-gp-route-translation-helpers.php
+++ b/includes/class-gp-route-translation-helpers.php
@@ -322,20 +322,36 @@ class GP_Route_Translation_Helpers extends GP_Route {
 		return home_url( gp_url_project( $permalink ) );
 	}
 
-	public static function get_translation_permalink( $project, $locale_slug, $translation_set_slug, $original_id, $translation_id ) {
-		if ( ! $project || ! $locale_slug || ! $translation_set_slug || ! $original_id || ! $translation_id ) {
+	/**
+	 * Gets the translation permalink.
+	 *
+	 * @param      GP_Project $project               The project.
+	 * @param      string     $locale_slug           The locale slug.
+	 * @param      string     $translation_set_slug  The translation set slug.
+	 * @param      int        $original_id           The original id.
+	 * @param      int        $translation_id        The translation id.
+	 *
+	 * @return     bool    The translation permalink.
+	 */
+	public static function get_translation_permalink( $project, $locale_slug, $translation_set_slug, $original_id, $translation_id = null ) {
+		if ( ! $project || ! $locale_slug || ! $translation_set_slug || ! $original_id ) {
 			return false;
+		}
+
+		$args = array(
+			'filters[original_id]' => $original_id,
+		);
+
+		if ( $translation_id ) {
+			$args['filters[status]']         = 'either';
+			$args['filters[translation_id]'] = $translation_id;
 		}
 
 		$translation_permalink = gp_url_project_locale(
 			$project,
 			$locale_slug,
 			$translation_set_slug,
-			array(
-				'filters[status]'         => 'either',
-				'filters[original_id]'    => $original_id,
-				'filters[translation_id]' => $translation_id,
-			)
+			$args
 		);
 		return $translation_permalink;
 	}

--- a/templates/original-permalink.php
+++ b/templates/original-permalink.php
@@ -38,11 +38,11 @@ gp_head();
 		esc_html_e( 'Singular: ' );
 	}
 
-	echo esc_html( $original->singular );
+	echo esc_translation( $original->singular );
 	if ( $original->plural ) {
 		echo '<br />';
 		esc_html_e( 'Plural: ' );
-		echo esc_html( $original->plural );
+		echo esc_translation( $original->plural );
 	}
 	?>
 </h1>
@@ -67,13 +67,13 @@ gp_head();
 				   ( '' == $translation->translation_3 ) && ( '' == $translation->translation_4 ) &&
 				   ( '' == $translation->translation_5 ) ) :
 			?>
-			<strong><?php echo $translation_permalink ? gp_link( $translation_permalink, $translation->translation_0 ) : esc_html( $translation->translation_0 ); ?></strong>
+			<strong><?php echo $translation_permalink ? gp_link( $translation_permalink, esc_translation( $translation->translation_0 ) ) : esc_translation( $translation->translation_0 ); ?></strong>
 		<?php else : ?>
 			<ul id="translation-list">
 			<?php for ( $i = 0; $i <= 5; $i++ ) : ?>
 				<?php if ( '' != $translation->{'translation_' . $i} ) : ?>
 					<li>
-						<?php echo $translation_permalink ? gp_link( $translation_permalink, $translation->{'translation_' . $i} ) : esc_html( $translation->{'translation_' . $i} ); ?>
+						<?php echo $translation_permalink ? gp_link( $translation_permalink, esc_translation( $translation->{'translation_' . $i} ) ) : esc_translation( $translation->{'translation_' . $i} ); ?>
 					</li>
 				<?php endif ?>
 			<?php endfor ?>
@@ -90,13 +90,13 @@ gp_head();
 					   ( '' == $e->translation_3 ) && ( '' == $e->translation_4 ) &&
 					   ( '' == $e->translation_5 ) ) :
 				?>
-				<strong><?php echo $translation_permalink ? gp_link( $translation_permalink, $e->translation_0 ) : esc_html( $e->translation_0 ); ?></strong>
+				<strong><?php echo $translation_permalink ? gp_link( $translation_permalink, esc_translation( $e->translation_0 ) ) : esc_translation( $e->translation_0 ); ?></strong>
 			<?php else : ?>
 				<ul id="translation-list">
 					<?php for ( $i = 0; $i <= 5; $i++ ) : ?>
 						<?php if ( '' != $e->{'translation_' . $i} ) : ?>
 							<li>
-								<?php echo $translation_permalink ? gp_link( $translation_permalink, $e->{'translation_' . $i} ) : esc_html( $e->{'translation_' . $i} ); ?>
+								<?php echo $translation_permalink ? gp_link( $translation_permalink, esc_translation( $e->{'translation_' . $i} ) ) : esc_translation( $e->{'translation_' . $i} ); ?>
 							</li>
 						<?php endif ?>
 					<?php endfor ?>
@@ -104,6 +104,18 @@ gp_head();
 			<?php endif ?>
 		</p>
 	<?php endforeach; ?>
+<?php elseif ( $translation_set ) : ?>
+	<?php
+	$translate_url = GP_Route_Translation_Helpers::get_translation_permalink(
+		$project,
+		$locale_slug,
+		$translation_set_slug,
+		$original_id
+	);
+	?>
+	<p>
+		<a href="<?php echo esc_url( $translate_url ); ?>"><?php esc_html_e( 'This string has no translation in this language.' ); ?></a>
+	</p>
 <?php else : ?>
 	<p>
 		<?php esc_html_e( 'This string has no translation in this language.' ); ?>


### PR DESCRIPTION
### Before
For this original https://glotpress.local/projects/wp-plugins/ultimate-tinymce/dev/726407/de/default/
<img width="1006" alt="Screenshot 2022-02-25 at 21 48 08" src="https://user-images.githubusercontent.com/203408/155800776-e6579346-f063-44c1-8163-167d3a2ab14d.png">

the original permalink is displayed like this:
<img width="957" alt="Screenshot 2022-02-25 at 21 49 50" src="https://user-images.githubusercontent.com/203408/155800870-a0a137e1-3106-4924-983d-b298c62c2271.png">

### After
This changes the escaping function to `esc_translation()` to not mangle the escaped HTML tags:
<img width="997" alt="Screenshot 2022-02-25 at 21 48 14" src="https://user-images.githubusercontent.com/203408/155800933-a18df3fa-8f80-4b52-ac1d-be909acc0f0e.png">

This also adds a link below the original to allow entering a translation (if viewed on an original page with locale)