### PR TITLE
Update the comment_author with the user_id reference in the $commentdata array

### DIFF
--- a/helpers/helper-translation-discussion.php
+++ b/helpers/helper-translation-discussion.php
@@ -230,7 +230,7 @@ class Helper_Translation_Discussion extends GP_Translation_Helper {
 		}
 
 		// If our user has already contributed translations, approve comment.
-		$user_current_translations = $wpdb->get_var( $wpdb->prepare( "SELECT COUNT(*) FROM $wpdb->gp_translations WHERE user_id = %s AND status = 'current'", $commentdata['comment_author'] ) );
+		$user_current_translations = $wpdb->get_var( $wpdb->prepare( "SELECT COUNT(*) FROM $wpdb->gp_translations WHERE user_id = %s AND status = 'current'", $commentdata['user_id'] ) );
 		if ( $user_current_translations ) {
 			$approved = true;
 		}


### PR DESCRIPTION
We used the $commentdata['comment_author'] in the SQL query, but the correct element is $commentdata['user_id'].
The documentation (https://developer.wordpress.org/reference/hooks/pre_comment_approved/) shows the field with the two last letters in uppercase (user_ID), but debugging it, the whole field is in lowercase (user_id).