### PR TITLE
Load reject reasons from backend

### DIFF
--- a/helpers/helper-translation-discussion.php
+++ b/helpers/helper-translation-discussion.php
@@ -64,6 +64,20 @@ class Helper_Translation_Discussion extends GP_Translation_Helper {
 
 	/**
 	 *
+	 * @since 0.0.2
+	 * @var array
+	 */
+	public static $reject_reasons = array(
+		'style'       => 'Style Guide',
+		'grammar'     => 'Grammar',
+		'branding'    => 'Branding',
+		'glossary'    => 'Glossary',
+		'punctuation' => 'Punctuation',
+		'typo'        => 'Typo',
+	);
+
+	/**
+	 *
 	 * @since 0.0.1
 	 * @var string
 	 */

--- a/helpers/helper-translation-discussion.php
+++ b/helpers/helper-translation-discussion.php
@@ -64,20 +64,6 @@ class Helper_Translation_Discussion extends GP_Translation_Helper {
 
 	/**
 	 *
-	 * @since 0.0.2
-	 * @var array
-	 */
-	public static $reject_reasons = array(
-		'style'       => 'Style Guide',
-		'grammar'     => 'Grammar',
-		'branding'    => 'Branding',
-		'glossary'    => 'Glossary',
-		'punctuation' => 'Punctuation',
-		'typo'        => 'Typo',
-	);
-
-	/**
-	 *
 	 * @since 0.0.1
 	 * @var string
 	 */
@@ -592,6 +578,25 @@ class Helper_Translation_Discussion extends GP_Translation_Helper {
 
 		return $original_id;
 	}
+
+	/**
+	 * Return an array of allowed rejection reasons
+	 *
+	 * @since 0.0.2
+	 *
+	 * @return array
+	 */
+	public static function get_reject_reasons() {
+		return array(
+			'style'       => __( 'Style Guide' ),
+			'grammar'     => __( 'Grammar' ),
+			'branding'    => __( 'Branding' ),
+			'glossary'    => __( 'Glossary' ),
+			'punctuation' => __( 'Punctuation' ),
+			'typo'        => __( 'Typo' ),
+		);
+	}
+
 }
 
 /**

--- a/includes/class-gp-translation-helpers.php
+++ b/includes/class-gp-translation-helpers.php
@@ -345,9 +345,19 @@ class GP_Translation_Helpers {
 			'gp-reject-feedback-js',
 			'$gp_reject_feedback_settings',
 			array(
-				'url'         => admin_url( 'admin-ajax.php' ),
-				'nonce'       => wp_create_nonce( 'gp_reject_feedback' ),
-				'locale_slug' => $translation_set['locale_slug'],
+				'url'            => admin_url( 'admin-ajax.php' ),
+				'nonce'          => wp_create_nonce( 'gp_reject_feedback' ),
+				'locale_slug'    => $translation_set['locale_slug'],
+				'reject_reasons' => json_encode(
+					array(
+						'style'       => 'Style Guide',
+						'grammar'     => 'Grammar',
+						'branding'    => 'Branding',
+						'glossary'    => 'Glossary',
+						'punctuation' => 'Punctuation',
+						'typo'        => 'Typo',
+					)
+				),
 			)
 		);
 	}

--- a/includes/class-gp-translation-helpers.php
+++ b/includes/class-gp-translation-helpers.php
@@ -348,7 +348,7 @@ class GP_Translation_Helpers {
 				'url'            => admin_url( 'admin-ajax.php' ),
 				'nonce'          => wp_create_nonce( 'gp_reject_feedback' ),
 				'locale_slug'    => $translation_set['locale_slug'],
-				'reject_reasons' => Helper_Translation_Discussion::$reject_reasons,
+				'reject_reasons' => Helper_Translation_Discussion::get_reject_reasons(),
 			)
 		);
 	}
@@ -368,7 +368,7 @@ class GP_Translation_Helpers {
 		$translation_id_array = array_map( array( $helper_discussion, 'sanitize_translation_id' ), $_POST['data']['translation_id'] );
 		$original_id_array    = array_map( array( $helper_discussion, 'sanitize_original_id' ), $_POST['data']['original_id'] );
 		$reject_reason        = ! empty( $_POST['data']['reason'] ) ? $_POST['data']['reason'] : array( 'other' );
-		$all_reject_reasons   = array_keys( Helper_Translation_Discussion::$reject_reasons );
+		$all_reject_reasons   = array_keys( Helper_Translation_Discussion::get_reject_reasons() );
 		$reject_reason        = array_filter(
 			$reject_reason,
 			function( $reason ) use ( $all_reject_reasons ) {

--- a/includes/class-gp-translation-helpers.php
+++ b/includes/class-gp-translation-helpers.php
@@ -348,16 +348,7 @@ class GP_Translation_Helpers {
 				'url'            => admin_url( 'admin-ajax.php' ),
 				'nonce'          => wp_create_nonce( 'gp_reject_feedback' ),
 				'locale_slug'    => $translation_set['locale_slug'],
-				'reject_reasons' => json_encode(
-					array(
-						'style'       => 'Style Guide',
-						'grammar'     => 'Grammar',
-						'branding'    => 'Branding',
-						'glossary'    => 'Glossary',
-						'punctuation' => 'Punctuation',
-						'typo'        => 'Typo',
-					)
-				),
+				'reject_reasons' => Helper_Translation_Discussion::$reject_reasons,
 			)
 		);
 	}

--- a/includes/class-gp-translation-helpers.php
+++ b/includes/class-gp-translation-helpers.php
@@ -368,7 +368,13 @@ class GP_Translation_Helpers {
 		$translation_id_array = array_map( array( $helper_discussion, 'sanitize_translation_id' ), $_POST['data']['translation_id'] );
 		$original_id_array    = array_map( array( $helper_discussion, 'sanitize_original_id' ), $_POST['data']['original_id'] );
 		$reject_reason        = ! empty( $_POST['data']['reason'] ) ? $_POST['data']['reason'] : array( 'other' );
-		$reject_reason        = array_map( 'sanitize_text_field', $reject_reason );
+		$all_reject_reasons   = array_keys( Helper_Translation_Discussion::$reject_reasons );
+		$reject_reason        = array_filter(
+			$reject_reason,
+			function( $reason ) use ( $all_reject_reasons ) {
+				return in_array( $reason, $all_reject_reasons );
+			}
+		);
 		$reject_comment       = sanitize_text_field( $_POST['data']['comment'] );
 
 		if ( ! $locale_slug || ! $translation_id_array || ! $original_id_array || ( ! $reject_reason && ! $reject_comment ) ) {

--- a/js/reject-feedback.js
+++ b/js/reject-feedback.js
@@ -1,4 +1,4 @@
-/* eslint-disable no-undef */
+/* global $gp, $gp_reject_feedback_settings, document, tb_show */
 ( function( $, $gp ) {
 	$( document ).ready(
 		function() {

--- a/js/reject-feedback.js
+++ b/js/reject-feedback.js
@@ -153,7 +153,7 @@
 	}
 
 	function getReasonList( displayType ) {
-		var rejectReasons = JSON.parse( $gp_reject_feedback_settings.reject_reasons );
+		var rejectReasons = $gp_reject_feedback_settings.reject_reasons;
 
 		var rejectList = '';
 		var prefix = '';

--- a/js/reject-feedback.js
+++ b/js/reject-feedback.js
@@ -1,19 +1,16 @@
+/* eslint-disable no-undef */
 ( function( $, $gp ) {
-	// eslint-disable-next-line no-undef
 	$( document ).ready(
 		function() {
 			var rowIds = '';
+
 			var feedbackForm = '<details><summary class="feedback-summary">Give feedback</summary>' +
 			'<div id="feedback-form">' +
 			'<form>' +
 			'<h3 class="feedback-reason-title">Reason</h3>' +
 			'<ul class="feedback-reason-list">' +
-			'<li><label><input type="checkbox" name="feedback_reason" value="style" />Style Guide</label></li>' +
-			'<li><label><input type="checkbox" name="feedback_reason" value="grammar" />Grammar</label></li>' +
-			'<li><label><input type="checkbox" name="feedback_reason" value="branding" />Branding</label></li>' +
-			'<li><label><input type="checkbox" name="feedback_reason" value="glossary" />Glossary</label></li>' +
-			'<li><label><input type="checkbox" name="feedback_reason" value="punctuation" />Punctuation</label></li>' +
-			'<li><label><input type="checkbox" name="feedback_reason" value="typo" />Typo</label></li></ul>' +
+			getReasonList( 'single' ) +
+			'</ul>' +
 			'<div class="feedback-comment">' +
 				'<label>Comment </label>' +
 				'<textarea name="feedback_comment"></textarea>' +
@@ -26,12 +23,7 @@
 			'<div id="reject-feedback-form" style="display:none;">' +
 			'<form>' +
 			'<h3>Reason</h3>' +
-			'<div class="modal-item"><label><input type="checkbox" name="modal_feedback_reason" value="style" />Style Guide </div></label>' +
-			'<div class="modal-item"><label><input type="checkbox" name="modal_feedback_reason" value="grammar" />Grammar </div></label>' +
-			'<div class="modal-item"><label><input type="checkbox" name="modal_feedback_reason" value="branding" />Branding </div></label>' +
-			'<div class="modal-item"><label><input type="checkbox" name="modal_feedback_reason" value="glossary" />Glossary </div></label>' +
-			'<div class="modal-item"><label><input type="checkbox" name="modal_feedback_reason" value="punctuation" />Punctuation </div></label>' +
-			'<div class="modal-item"><label><input type="checkbox" name="modal_feedback_reason" value="typo" />Typo </div></label>' +
+			getReasonList( 'bulk' ) +
 			'<div class="modal-comment">' +
 					'<label>Comment </label>' +
 					'<textarea name="modal_feedback_comment"></textarea>' +
@@ -54,7 +46,7 @@
 				if ( $( 'select[name="bulk[action]"]' ).val() === 'reject' ) {
 					e.preventDefault();
 					e.stopImmediatePropagation();
-					// eslint-disable-next-line no-undef
+
 					tb_show( 'Reject with Feedback', '#TB_inline?inlineId=reject-feedback-form' );
 				}
 			} );
@@ -86,7 +78,6 @@
 					$( 'form.filters-toolbar.bulk-actions' ).submit();
 				}
 
-				// eslint-disable-next-line no-undef
 				rejectData.locale_slug = $gp_reject_feedback_settings.locale_slug;
 				rejectData.reason = rejectReason;
 				rejectData.comment = comment;
@@ -118,7 +109,6 @@
 			return;
 		}
 
-		// eslint-disable-next-line no-undef
 		rejectData.locale_slug = $gp_reject_feedback_settings.locale_slug;
 		rejectData.reason = rejectReason;
 		rejectData.comment = comment;
@@ -138,14 +128,14 @@
 		data = {
 			action: 'reject_with_feedback',
 			data: rejectData,
-			// eslint-disable-next-line no-undef
+
 			_ajax_nonce: $gp_reject_feedback_settings.nonce,
 		};
 
 		$.ajax(
 			{
 				type: 'POST',
-				// eslint-disable-next-line no-undef
+
 				url: $gp_reject_feedback_settings.url,
 				data: data,
 			}
@@ -161,6 +151,29 @@
 			}
 		);
 	}
-// eslint-disable-next-line no-undef
+
+	function getReasonList( displayType ) {
+		var rejectReasons = JSON.parse( $gp_reject_feedback_settings.reject_reasons );
+
+		var rejectList = '';
+		var prefix = '';
+		var suffix = '';
+		var inputName = '';
+		if ( displayType === 'single' ) {
+			prefix = '<li><label>';
+			suffix = '</label></li>';
+			inputName = 'feedback_reason';
+		} else {
+			prefix = '<div class="modal-item"><label>';
+			suffix = '</div></label>';
+			inputName = 'modal_feedback_reason';
+		}
+
+		// eslint-disable-next-line vars-on-top
+		for ( var reason in rejectReasons ) {
+			rejectList += prefix + '<input type="checkbox" name="' + inputName + '" value="' + reason + '" />' + rejectReasons[ reason ] + suffix;
+		}
+		return rejectList;
+	}
 }( jQuery, $gp )
 );


### PR DESCRIPTION
Before now, list of reject reasons are manually added to the rejection forms in the frontend.

This PR allows us fetch list of reject reasons from the backend and this also allows easy updating of the reasons without having to make changes in several parts of the code.