### PR TITLE
Load discussion tab inline without AJAX

### DIFF
--- a/templates/original-permalink.php
+++ b/templates/original-permalink.php
@@ -139,8 +139,16 @@ gp_tmpl_header();
 	foreach ( $sections as $section ) {
 		printf( '<div class="%s helper %s" id="%s">', esc_attr( $section['classname'] ), esc_attr( $is_first_class ), esc_attr( $section['id'] ) );
 		if ( $section['has_async_content'] ) {
-			echo '<div class="async-content"></div>';
+			if ( 'helper-translation-discussion' == $section['classname'] ) {
+				echo '<div class="async-content">';
+				gp_tmpl_load( 'translation-discussion-comments', get_defined_vars(), dirname( dirname( __FILE__ ) ) . '/helpers-assets/templates' );
+				echo '</div>';
+				$section['content'] = '';
+			} else {
+				echo '<div class="async-content"></div>';
+			}
 		}
+
 		echo wp_kses_post( $section['content'] );
 		echo '</div>';
 		$is_first_class = '';


### PR DESCRIPTION
Issue: Linking to the exact comment with e.g  #comment-123 in the url is currently broken and this is due to loading the content via AJAX.

This PR fixes the above issue by loading the comments template  as a child of `<div class="async-content">` on page load, instead of loading empty `<div class="async-content"></div>` for the discussions tab.