### PR TITLE
Show waiting translation in comment footer

### DIFF
--- a/includes/class-gp-route-translation-helpers.php
+++ b/includes/class-gp-route-translation-helpers.php
@@ -161,6 +161,9 @@ class GP_Route_Translation_Helpers extends GP_Route {
 				);
 			}
 		}
+		if ( ! $translation_id ) {
+			$translation_id = ! empty( $existing_translations ) ? end( $existing_translations )->id : null;
+		}
 
 		$priorities_key_value = $original->get_static( 'priorities' );
 		$priority             = $priorities_key_value[ $original->priority ];

--- a/templates/original-permalink.php
+++ b/templates/original-permalink.php
@@ -54,10 +54,14 @@ gp_tmpl_header();
 				$original_id,
 				$translation_id
 			);
-		}
+		};
+		$row_translation_id = null;
 		?>
 <?php if ( $translation ) : ?>
-	<?php $translation_permalink = $generate_permalink( $translation->id ); ?>
+	<?php
+		$row_translation_id    = $translation->id;
+		$translation_permalink = $generate_permalink( $translation->id );
+	?>
 	<p>
 	
 		<?php echo esc_html( ucfirst( $translation->status ) ); ?> translation:
@@ -80,7 +84,9 @@ gp_tmpl_header();
 		<?php endif ?>
 	</p>
 <?php elseif ( $existing_translations ) : ?>
+	<?php $row_translation_id = end( $existing_translations )->id; ?>
 	<?php foreach ( $existing_translations as $e ) : ?>
+		
 		<p>
 		<?php $translation_permalink = $generate_permalink( $e->id ); ?>
 			<?php echo esc_html( ucfirst( $e->status ) ); ?> translation:
@@ -120,7 +126,7 @@ gp_tmpl_header();
 		<?php esc_html_e( 'This string has no translation in this language.' ); ?>
 	</p>
 <?php endif; ?>
-<div class="translations" row="<?php echo esc_attr( $row_id . ( $translation ? '-' . $translation->id : '' ) ); ?>" replytocom="<?php echo esc_attr( gp_get( 'replytocom' ) ); ?>" >
+<div class="translations" row="<?php echo esc_attr( $row_id . '-' . $row_translation_id ); ?>" replytocom="<?php echo esc_attr( gp_get( 'replytocom' ) ); ?>" >
 <div class="translation-helpers">
 	<nav>
 		<ul class="helpers-tabs">


### PR DESCRIPTION
#### Problem
The translation in the comment footer is only added when the status of the translation is `rejected`, otherwise it's blank. When reading through the comments on the discussions page, it's difficult to tell what the translation was, when a comment was made for proper context.

<img width="945" alt="Screenshot 2022-05-10 at 15 37 26" src="https://user-images.githubusercontent.com/2834132/167658442-ff7129a7-2136-4d51-a889-3354377dcc65.png">

#### Solution
The most recent translation is added in the comment footer regardless of the status of the translation. This way, when we see a comment and the translation in the footer we can correctly interpret the context of the comment.
<img width="941" alt="Screenshot 2022-05-10 at 15 38 09" src="https://user-images.githubusercontent.com/2834132/167656892-242abaa7-4a0a-4bbd-bf65-20a94d130f07.png">

<img width="966" alt="Screenshot 2022-05-10 at 15 56 42" src="https://user-images.githubusercontent.com/2834132/167659089-dc9265c8-6f77-46a7-9769-9f41f839f4cb.png">

#### Testing instructions
Find translations with status set as `current`, `waiting` , `rejected` or `fuzzy` and post a comment on its discussions page.
The most recent translation will be added to the comment footer regardless of its status.