### PR TITLE
Check for empty translationIds before bulk rejection

### DIFF
--- a/includes/class-gp-translation-helpers.php
+++ b/includes/class-gp-translation-helpers.php
@@ -372,8 +372,8 @@ class GP_Translation_Helpers {
 
 		$helper_discussion    = new Helper_Translation_Discussion();
 		$locale_slug          = $helper_discussion->sanitize_comment_locale( sanitize_text_field( $_POST['data']['locale_slug'] ) );
-		$translation_id_array = array_map( array( $helper_discussion, 'sanitize_translation_id' ), $_POST['data']['translation_id'] );
-		$original_id_array    = array_map( array( $helper_discussion, 'sanitize_original_id' ), $_POST['data']['original_id'] );
+		$translation_id_array = ! empty( $_POST['data']['translation_id'] ) ? array_map( array( $helper_discussion, 'sanitize_translation_id' ), $_POST['data']['translation_id'] ) : null;
+		$original_id_array    = ! empty( $_POST['data']['original_id'] ) ? array_map( array( $helper_discussion, 'sanitize_original_id' ), $_POST['data']['original_id'] ) : null;
 		$reject_reason        = ! empty( $_POST['data']['reason'] ) ? $_POST['data']['reason'] : array( 'other' );
 		$all_reject_reasons   = array_keys( Helper_Translation_Discussion::get_reject_reasons() );
 		$reject_reason        = array_filter(

--- a/js/reject-feedback.js
+++ b/js/reject-feedback.js
@@ -45,6 +45,7 @@
 					if( selectedRow.hasClass( 'status-current' ) ){
 						return selectedRow.attr( 'row' );
 					}
+					$( this ).prop( "checked", false );
 				} ).get().join( ',' );
 				if ( $( 'select[name="bulk[action]"]' ).val() === 'reject' ) {
 					e.preventDefault();

--- a/js/reject-feedback.js
+++ b/js/reject-feedback.js
@@ -53,18 +53,22 @@
 
 			$( 'body' ).on( 'click', '#modal-reject-btn', function( e ) {
 				var rowIdsArray = rowIds.split( ',' );
-
-				var originalIds = rowIdsArray.map( function( rowId ) {
-					return $gp.editor.original_id_from_row_id( rowId );
-				} );
-				var translationIds = rowIdsArray.map( function( rowId ) {
-					return $gp.editor.translation_id_from_row_id( rowId );
-				} );
-
+				var translationIds = [];
+				var originalIds = [];
 				var comment = '';
 				var rejectReason = [];
 				var rejectData = {};
 				var form = $( this ).closest( 'form' );
+
+				rowIdsArray.forEach( function( rowId ) {
+					var originalId = $gp.editor.original_id_from_row_id( rowId );
+					var translationId = $gp.editor.translation_id_from_row_id( rowId );
+
+					if ( originalId && translationId ) {
+						originalIds.push( originalId );
+						translationIds.push( translationId );
+					}
+				} );
 
 				form.find( 'input[name="modal_feedback_reason"]:checked' ).each(
 					function() {
@@ -74,8 +78,9 @@
 
 				comment = form.find( 'textarea[name="modal_feedback_comment"]' ).val();
 
-				if ( ! comment.trim().length && ! rejectReason.length ) {
+				if ( ( ! comment.trim().length && ! rejectReason.length ) || ( ! translationIds.length || ! originalIds.length ) ) {
 					$( 'form#bulk-actions-toolbar-top' ).submit();
+
 				}
 
 				rejectData.locale_slug = $gp_reject_feedback_settings.locale_slug;

--- a/js/reject-feedback.js
+++ b/js/reject-feedback.js
@@ -85,7 +85,6 @@
 
 				if ( ( ! comment.trim().length && ! rejectReason.length ) || ( ! translationIds.length || ! originalIds.length ) ) {
 					$( 'form#bulk-actions-toolbar-top' ).submit();
-
 				}
 
 				rejectData.locale_slug = $gp_reject_feedback_settings.locale_slug;

--- a/js/reject-feedback.js
+++ b/js/reject-feedback.js
@@ -41,7 +41,10 @@
 
 			$( '#bulk-actions-toolbar-top .button, #bulk-actions-toolbar .button' ).click( function( e ) {
 				rowIds = $( 'input:checked', $( 'table#translations th.checkbox' ) ).map( function() {
-					return $( this ).parents( 'tr.preview' ).attr( 'row' );
+					var selectedRow = $( this ).parents( 'tr.preview' );
+					if( selectedRow.hasClass( 'status-current' ) ){
+						return selectedRow.attr( 'row' );
+					}
 				} ).get().join( ',' );
 				if ( $( 'select[name="bulk[action]"]' ).val() === 'reject' ) {
 					e.preventDefault();

--- a/js/reject-feedback.js
+++ b/js/reject-feedback.js
@@ -2,8 +2,7 @@
 ( function( $, $gp ) {
 	$( document ).ready(
 		function() {
-			var rowIds = '';
-
+			var rowIds = [];
 			var feedbackForm = '<details><summary class="feedback-summary">Give feedback</summary>' +
 			'<div id="feedback-form">' +
 			'<form>' +
@@ -47,7 +46,7 @@
 					}
 					$( this ).prop( 'checked', false );
 					return null;
-				} ).get().join( ',' );
+				} ).get();
 				if ( $( 'select[name="bulk[action]"]' ).val() === 'reject' ) {
 					e.preventDefault();
 					e.stopImmediatePropagation();
@@ -57,7 +56,6 @@
 			} );
 
 			$( 'body' ).on( 'click', '#modal-reject-btn', function( e ) {
-				var rowIdsArray = rowIds.split( ',' );
 				var translationIds = [];
 				var originalIds = [];
 				var comment = '';
@@ -65,7 +63,7 @@
 				var rejectData = {};
 				var form = $( this ).closest( 'form' );
 
-				rowIdsArray.forEach( function( rowId ) {
+				rowIds.forEach( function( rowId ) {
 					var originalId = $gp.editor.original_id_from_row_id( rowId );
 					var translationId = $gp.editor.translation_id_from_row_id( rowId );
 

--- a/js/reject-feedback.js
+++ b/js/reject-feedback.js
@@ -42,10 +42,11 @@
 			$( '#bulk-actions-toolbar-top .button, #bulk-actions-toolbar .button' ).click( function( e ) {
 				rowIds = $( 'input:checked', $( 'table#translations th.checkbox' ) ).map( function() {
 					var selectedRow = $( this ).parents( 'tr.preview' );
-					if( selectedRow.hasClass( 'status-current' ) ){
+					if ( selectedRow.hasClass( 'status-current' ) ) {
 						return selectedRow.attr( 'row' );
 					}
-					$( this ).prop( "checked", false );
+					$( this ).prop( 'checked', false );
+					return null;
 				} ).get().join( ',' );
 				if ( $( 'select[name="bulk[action]"]' ).val() === 'reject' ) {
 					e.preventDefault();


### PR DESCRIPTION
#### Problem
When you try to reject strings that have no translations, the ajax call on clicking the "Reject" button on the popover returns a 500 error

#### Solution
Check that the strings have a translation before making the ajax call, otherwise if they have no translation(s), submit the form with empty values and the default message e.g "0 translations were rejected" will be displayed.

#### Testing instructions
To reproduce the issue, do a git checkout to the `main` branch and follow the steps below;

> For a project, use the "Untranslated' filter as shown below;

<img width="991" alt="Screenshot 2022-04-19 at 11 59 29" src="https://user-images.githubusercontent.com/2834132/163989691-bc38aa13-2308-4162-9dbf-77f39b590f8e.png">

>Then select a couple of untranslated strings and choose "Reject" in the action dropdown and click "Apply". 
<img width="986" alt="Screenshot 2022-04-19 at 12 00 00" src="https://user-images.githubusercontent.com/2834132/163989888-e73830ba-6d06-44cc-a91c-55d5aca2e486.png">

>Fill the form that shows on the popover and click "Reject". You would see the error in the browser console.
<img width="1440" alt="Screenshot 2022-04-19 at 11 50 25" src="https://user-images.githubusercontent.com/2834132/163989927-90f2bb33-22ba-4459-a757-68dc00f19193.png">

To test the solution go a git checkout to the `no-translation-reject` branch and repeat the steps above, the page should reload and a notice that reads "0 translations were rejected." should be shown above the page content as shown below.
<img width="1033" alt="Screenshot 2022-04-19 at 12 07 18" src="https://user-images.githubusercontent.com/2834132/163990748-c629aa98-733f-4b9e-9b71-1e5db656b6f1.png">


