### PR TITLE
Disable all the comment buttons when the user clicks on it

### DIFF
--- a/helpers-assets/js/translation-discussion.js
+++ b/helpers-assets/js/translation-discussion.js
@@ -32,6 +32,8 @@ jQuery( function( $ ) {
 		e.preventDefault();
 		e.stopImmediatePropagation();
 
+		$( 'input.submit' ).prop( 'disabled', true );
+
 		if ( ! formdata.meta.translation_id ) {
 			formdata.meta.translation_id = 0;
 		}


### PR DESCRIPTION
Disable all the "Post Comment" buttons when the user clicks on it, so we avoid having multiple requests. I disable another "Post Comment" buttons, so we avoid sending a new post comment request when another one is being processed. 