### PR TITLE
Add a link to open the discussion in a different tab

### DIFF
--- a/includes/class-gp-translation-helpers.php
+++ b/includes/class-gp-translation-helpers.php
@@ -102,6 +102,8 @@ class GP_Translation_Helpers {
 	 *
 	 * @since 0.0.2
 	 *
+	 * @todo Move the inline CSS style to a CSS file when this plugin be integrated into GlotPress.
+	 *
 	 * @param array              $more_links         The links to be output.
 	 * @param GP_Project         $project            Project object.
 	 * @param GP_Locale          $locale             Locale object.
@@ -113,7 +115,9 @@ class GP_Translation_Helpers {
 	public function translation_row_template_more_links( array $more_links, GP_Project $project, GP_Locale $locale, GP_Translation_Set $translation_set, Translation_Entry $translation ): array {
 		$permalink = GP_Route_Translation_Helpers::get_permalink( $project->path, $translation->original_id, $translation_set->slug, $translation_set->locale );
 
-		$more_links['discussion'] = '<a href="' . esc_url( $permalink ) . '">Discussion</a>';
+		$links                    = '<a href="' . esc_url( $permalink ) . '">Discussion</a>';
+		$links                   .= '<a href="' . esc_url( $permalink ) . '" style="float:right" target="_blank"><span class="dashicons dashicons-external"></span></a>';
+		$more_links['discussion'] = $links;
 
 		return $more_links;
 	}


### PR DESCRIPTION
When you are in the main GlotPress page, if you clic on the "Discussion" link, the discussion page loads in the same tab.

![image](https://user-images.githubusercontent.com/1667814/160236710-ab869c5e-f07c-4bb5-bbe9-7ffc39cfd1df.png)

This PR adds an element to open the discussion in a new tab.

![image](https://user-images.githubusercontent.com/1667814/160236648-8d1ce0c2-f16a-41f0-8570-00066fdcd16c.png)

Considerations:
- I used an icon from the Dashicons family, which comes with WordPress. I think it is the icon that best represents the opening of the link in a new window.
- I have added the CSS inline, because at the time of loading the link, the CSS of the plugin is not yet loaded. This CSS will have to be moved to the GlotPress CSS when the plugin is merged into GlotPress. I have added a to-do in the function header to remember it.