### PR TITLE
Add current user_id to comment data

### DIFF
--- a/includes/class-gp-translation-helpers.php
+++ b/includes/class-gp-translation-helpers.php
@@ -417,6 +417,7 @@ class GP_Translation_Helpers {
 					'translation_id' => $translation_id,
 					'locale'         => $locale_slug,
 				),
+				'user_id'         => get_current_user_id(),
 			)
 		);
 


### PR DESCRIPTION
Before, when a bulk rejection is done and a feedback added, it shows the comment author as anonymous on the discussions tab even though the user is logged in. This is due to missing `user_id` parameter for the `wp_insert_comment` function.

This PR adds the current user_id to the comment data submitted when doing a bulk rejection.