### PR TITLE
Reject when both reason and comment are empty

### DIFF
--- a/js/reject-feedback.js
+++ b/js/reject-feedback.js
@@ -106,6 +106,7 @@
 		comment = div.find( 'textarea[name="feedback_comment"]' ).val();
 
 		if ( ! comment.trim().length && ! rejectReason.length ) {
+			$gp.editor.set_status( button, 'rejected' );
 			return;
 		}
 


### PR DESCRIPTION
This PR fixes the bug where the reject button doesn't work when there's no comment entered or reason selected.
Now, you can reject a single translation without having to enter any feedback.