### PR TITLE
GP Template: Fix jQuery selector for 'Reject' button on popover 

### DIFF
--- a/js/reject-feedback.js
+++ b/js/reject-feedback.js
@@ -75,7 +75,7 @@
 				comment = form.find( 'textarea[name="modal_feedback_comment"]' ).val();
 
 				if ( ! comment.trim().length && ! rejectReason.length ) {
-					$( 'form.filters-toolbar.bulk-actions' ).submit();
+					$( 'form#bulk-actions-toolbar-top' ).submit();
 				}
 
 				rejectData.locale_slug = $gp_reject_feedback_settings.locale_slug;
@@ -143,7 +143,7 @@
 		).done(
 			function() {
 				if ( rejectData.is_bulk_reject ) {
-					$( 'form.filters-toolbar.bulk-actions' ).submit();
+					$( 'form#bulk-actions-toolbar-top' ).submit();
 				} else {
 					$gp.editor.set_status( button, 'rejected' );
 					div.find( 'input[name="feedback_reason"]' ).prop( 'checked', false );


### PR DESCRIPTION
#### Problem
When trying to do a bulk rejection a GlotPress template environment, the `Reject` button in the popover does not work when clicked in GlotPress template. This PR fixes the issue by modifying the jQuery selector used.
<img width="1266" alt="Screenshot 2022-04-19 at 12 22 24" src="https://user-images.githubusercontent.com/2834132/163992986-8de71108-26f0-4b65-b124-a3c80ccd5eca.png">

#### Solution
The button selector used in jQuery has been modified to use the ID  attribute of the reject button.

#### Testing instructions
Please follow the steps indicated in the screenshot to test on the `main` branch to reproduce the problem and on the `glotpress-reject-btn` to see the solution.
<img width="1440" alt="Screenshot 2022-04-19 at 12 12 39" src="https://user-images.githubusercontent.com/2834132/163992296-189d8ca6-09a8-4742-b4f3-1b4d05b3deaf.png">

For the solution, the page will be reloaded and a notice displayed as seen below;
<img width="1424" alt="Screenshot 2022-04-19 at 12 19 59" src="https://user-images.githubusercontent.com/2834132/163992634-7b073e66-f461-4e5e-9719-6e788150093d.png">

