### PR TITLE
Proof of Concept: Rename Reject to Request Changes

### DIFF
--- a/css/discussion.css
+++ b/css/discussion.css
@@ -204,3 +204,22 @@ div#TB_ajaxWindowTitle {
 	margin-top: 2em;
 	float: none;
 }
+/* Override default rejected color */
+table.translations tr.preview.status-rejected,
+#legend .status-rejected {
+	background-color: #90c0eb !important;
+}
+
+.ct-chart-contributors .ct-series-c .ct-area { /* rejected */
+	fill: #90c0eb !important;
+	fill-opacity: .5;
+}
+
+.ct-legend .ct-series-2:before { /* rejected */
+	background-color: #90c0eb !important;
+	border-color: #90c0eb !important;
+}
+
+.ct-legend .ct-series-2:before { /* rejected */
+	background-color: #90c0eb !important;
+}

--- a/gp-translation-helpers.php
+++ b/gp-translation-helpers.php
@@ -31,6 +31,7 @@
 
 require_once __DIR__ . '/includes/class-gp-route-translation-helpers.php';
 require_once __DIR__ . '/includes/class-gp-translation-helpers.php';
+require_once __DIR__ . '/includes/class-gth-temporary-post.php';
 require_once __DIR__ . '/includes/class-gp-notifications.php';
 require_once __DIR__ . '/includes/class-wporg-notifications.php';
 require_once __DIR__ . '/includes/class-wporg-customization.php';

--- a/helpers-assets/js/translation-discussion.js
+++ b/helpers-assets/js/translation-discussion.js
@@ -1,23 +1,26 @@
+/* global $gp, document, wpApiSettings */
 jQuery( function( $ ) {
-	$( '.helper-translation-discussion' ).on( 'click', '.comments-selector a', function( e ) {
+	$( document ).on( 'click', '.helper-translation-discussion .comments-selector a', function( e ) {
+		var $comments, $selector;
+
 		e.preventDefault();
 		$( '.comments-selector a' ).removeClass( 'active-link' );
 		$( this ).addClass( 'active-link' );
-		var $comments = jQuery( e.target ).parents( 'h6' ).next( '.discussion-list' ); // eslint-disable-line vars-on-top
-		var selector = $( e.target ).data( 'selector' ); // eslint-disable-line vars-on-top
-		if ( 'all' === selector ) {
+		$comments = jQuery( e.target ).parents( 'h6' ).next( '.discussion-list' );
+		$selector = $( e.target ).data( 'selector' );
+		if ( 'all' === $selector ) {
 			$comments.children().show();
-		} else if ( 'rejection-feedback' === selector ) {
+		} else if ( 'rejection-feedback' === $selector ) {
 			$comments.children().hide();
 			$comments.children( '.rejection-feedback' ).show();
 		} else {
 			$comments.children().hide();
-			$comments.children( '.comment-locale-' + selector ).show();
-			$comments.children( '.comment-locale-' + selector ).next( 'ul' ).show();
+			$comments.children( '.comment-locale-' + $selector ).show();
+			$comments.children( '.comment-locale-' + $selector ).next( 'ul' ).show();
 		}
 		return false;
 	} );
-	$( '.helper-translation-discussion' ).on( 'submit', '.comment-form', function( e ) {
+	$( document ).on( 'submit', '.helper-translation-discussion .comment-form', function( e ) {
 		var $commentform = $( e.target );
 		var formdata = {
 			content: $commentform.find( 'textarea[name=comment]' ).val(),
@@ -49,10 +52,10 @@ jQuery( function( $ ) {
 		}
 
 		$.ajax( {
-			url: wpApiSettings.root + 'wp/v2/comments', // eslint-disable-line no-undef
+			url: wpApiSettings.root + 'wp/v2/comments',
 			method: 'POST',
 			beforeSend: function( xhr ) {
-				xhr.setRequestHeader( 'X-WP-Nonce', wpApiSettings.nonce ); // eslint-disable-line no-undef
+				xhr.setRequestHeader( 'X-WP-Nonce', wpApiSettings.nonce );
 			},
 			data: formdata,
 		} ).done( function( response ) {
@@ -61,7 +64,7 @@ jQuery( function( $ ) {
 				// TODO: error handling.
 			} else {
 				$commentform.find( 'textarea[name=comment]' ).val( '' );
-				$gp.translation_helpers.fetch( 'discussion' ); // eslint-disable-line no-undef
+				$gp.translation_helpers.fetch( 'discussion' );
 			}
 		} );
 

--- a/helpers-assets/templates/translation-discussion-comments.php
+++ b/helpers-assets/templates/translation-discussion-comments.php
@@ -14,7 +14,7 @@
 		<?php if ( $locale_slug ) : ?>
 			(<?php echo esc_html( $locale_slug ); ?>)
 			<?php
-			$locale_comments_count = 0;
+			$locale_comments_count    = 0;
 			$count_rejection_feedback = 0;
 			foreach ( $comments as $_comment ) {
 				$comment_locale = get_comment_meta( $_comment->comment_ID, 'locale', true );
@@ -85,15 +85,22 @@
 		2
 	);
 
-	if ( is_user_logged_in() ) {
+	if ( is_user_logged_in() && isset( $post ) ) {
+		if ( $post instanceof Gth_Temporary_Post ) {
+			$_post_id = $post->ID;
+			$post_obj = $post;
+		} else {
+			$post_obj = $post->ID;
+			$_post_id = $post->ID;
+		}
 		comment_form(
-			$args = array(
+			array(
 				'title_reply'         => __( 'Discuss this string' ),
 				/* translators: username */
 				'title_reply_to'      => __( 'Reply to %s' ),
 				'title_reply_before'  => '<h5 id="reply-title" class="discuss-title">',
 				'title_reply_after'   => '</h5>',
-				'id_form'             => 'commentform-' . $post_id,
+				'id_form'             => 'commentform-' . $_post_id,
 				'cancel_reply_link'   => '<span></span>',
 				'format'              => 'html5',
 				'comment_notes_after' => implode(
@@ -105,7 +112,7 @@
 					)
 				),
 			),
-			$post_id
+			$post_obj
 		);
 	} else {
 		/* translators: Log in URL. */

--- a/helpers-assets/templates/translation-discussion-comments.php
+++ b/helpers-assets/templates/translation-discussion-comments.php
@@ -4,38 +4,40 @@
  */
 ?>
 <div class="discussion-wrapper">
-	<?php if ( $number = count( $comments ) ) : ?>
+	<?php if ( $comments ) : ?>
 
 		<h6>
 			<?php
 			/* translators: number of comments. */
-			printf( _n( '%s Comment', '%s Comments', $number ), number_format_i18n( $number ) );
+			printf( _n( '%s Comment', '%s Comments', count( $comments ) ), number_format_i18n( count( $comments ) ) );
 			?>
 		<?php if ( $locale_slug ) : ?>
 			(<?php echo esc_html( $locale_slug ); ?>)
 			<?php
-			$count_locale_comments    = 0;
+			$locale_comments_count = 0;
 			$count_rejection_feedback = 0;
 			foreach ( $comments as $_comment ) {
 				$comment_locale = get_comment_meta( $_comment->comment_ID, 'locale', true );
 				if ( $locale_slug == $comment_locale ) {
-					$count_locale_comments++;
 
 					$reject_reason = get_comment_meta( $_comment->comment_ID, 'reject_reason', true );
 					if ( ! empty( $reject_reason ) ) {
 						$count_rejection_feedback++;
 					}
+					$locale_comments_count++;
 				}
 			}
 			?>
-		
+
 			<span class="comments-selector">
-				<a href="#" class="active-link" data-selector="all">Show all (<?php echo esc_html( $number ); ?>)</a> | 
-				<a href="#" data-selector="<?php echo esc_attr( $locale_slug ); ?>"><?php echo esc_html( $locale_slug ); ?> only (<?php echo esc_html( $count_locale_comments ); ?>)</a> | 
+				<a href="#" class="active-link" data-selector="all">Show all (<?php echo esc_html( count( $comments ) ); ?>)</a> |
+				<a href="#" data-selector="<?php echo esc_attr( $locale_slug ); ?>"><?php echo esc_html( $locale_slug ); ?> only (<?php echo esc_html( $locale_comments_count ); ?>)</a> |
 				<a href="#" data-selector="rejection-feedback">Rejection Feedback (<?php echo esc_html( $count_rejection_feedback ); ?>)</a>
 			</span>
 		<?php endif; ?>
 		</h6>
+	<?php else : ?>
+		<?php esc_html_e( 'No comments have been made on this yet.' ); ?>
 	<?php endif; ?>
 	<ul class="discussion-list">
 		<?php

--- a/helpers/base-helper.php
+++ b/helpers/base-helper.php
@@ -86,6 +86,16 @@ class GP_Translation_Helper {
 	public function has_async_content(): bool {
 		return $this->has_async_content ?? false;
 	}
+	/**
+	 * Indicates whether the helper should initally load inline
+	 *
+	 * @since 0.0.2
+	 *
+	 * @return bool
+	 */
+	public function load_inline(): bool {
+		return $this->load_inline ?? false;
+	}
 
 	/**
 	 * Gets the class name for the helper div.
@@ -228,7 +238,7 @@ class GP_Translation_Helper {
 	 * @return string
 	 */
 	public function get_output(): string {
-		if ( $this->has_async_content ) {
+		if ( ! $this->load_inline() ) {
 			return '<div class="loading">Loading&hellip;</div>';
 		}
 		return $this->async_output_callback( $this->get_async_content() );

--- a/helpers/base-helper.php
+++ b/helpers/base-helper.php
@@ -228,7 +228,10 @@ class GP_Translation_Helper {
 	 * @return string
 	 */
 	public function get_output(): string {
-		return '<div class="loading">Loading&hellip;</div>';
+		if ( $this->has_async_content ) {
+			return '<div class="loading">Loading&hellip;</div>';
+		}
+		return $this->async_output_callback( $this->get_async_content() );
 	}
 
 	/**

--- a/helpers/helper-other-locales.php
+++ b/helpers/helper-other-locales.php
@@ -39,7 +39,7 @@ class Helper_Other_Locales extends GP_Translation_Helper {
 	 * @return bool
 	 */
 	public function activate(): bool {
-		if ( ! $this->data['project_id'] ) {
+		if ( ! $this->data['project'] ) {
 			return false;
 		}
 
@@ -58,7 +58,7 @@ class Helper_Other_Locales extends GP_Translation_Helper {
 	 * @return array|void
 	 */
 	public function get_async_content() {
-		if ( ! $this->data['project_id'] ) {
+		if ( ! $this->data['project'] ) {
 			return;
 		}
 		$translation_set = null;

--- a/helpers/helper-translation-discussion.php
+++ b/helpers/helper-translation-discussion.php
@@ -387,15 +387,6 @@ class Helper_Translation_Discussion extends GP_Translation_Helper {
 		// Disable subscribe to comments for now.
 		add_filter( 'option_stc_disabled', '__return_true' );
 
-		// Link comment author to WordPress.org profile.
-		add_filter(
-			'get_comment_author_link',
-			function() {
-					$comment_author = get_comment_author();
-					return '<a href="https://profiles.wordpress.org/' . $comment_author . '">' . $comment_author . '</a>';
-			}
-		);
-
 		add_filter(
 			'comment_form_logged_in',
 			function( $logged_in_as, $commenter, $user_identity ) {

--- a/helpers/helper-translation-discussion.php
+++ b/helpers/helper-translation-discussion.php
@@ -29,7 +29,7 @@ class Helper_Translation_Discussion extends GP_Translation_Helper {
 	 * @since 0.0.1
 	 * @var bool
 	 */
-	public $has_async_content = true;
+	public $has_async_content = false;
 
 	/**
 	 * The post type used to store the comments.
@@ -364,7 +364,6 @@ class Helper_Translation_Discussion extends GP_Translation_Helper {
 				'status'             => 'approve',
 				'type'               => 'comment',
 				'include_unapproved' => array( get_current_user_id() ),
-				'order'              => 'ASC',
 			)
 		);
 	}
@@ -397,6 +396,26 @@ class Helper_Translation_Discussion extends GP_Translation_Helper {
 			}
 		);
 
+		add_filter(
+			'comment_form_logged_in',
+			function( $logged_in_as, $commenter, $user_identity ) {
+				/* translators: Username with which the user is logged in */
+				return sprintf( '<p class="logged-in-as">%s</p>', sprintf( __( 'Logged in as %s.' ), $user_identity ) );
+			},
+			10,
+			3
+		);
+
+		add_filter(
+			'comment_form_fields',
+			function( $comment_fields ) {
+				$comment_fields['comment'] = str_replace( '>Comment<', '>Please leave your comment about this string here:<', $comment_fields['comment'] );
+				return $comment_fields;
+			}
+		);
+
+		remove_action( 'comment_form_top', 'rosetta_comment_form_support_hint' );
+
 		$output = gp_tmpl_get_output(
 			'translation-discussion-comments',
 			array(
@@ -404,7 +423,7 @@ class Helper_Translation_Discussion extends GP_Translation_Helper {
 				'post_id'              => self::get_shadow_post( $this->data['original_id'] ),
 				'translation_id'       => isset( $this->data['translation_id'] ) ? $this->data['translation_id'] : null,
 				'locale_slug'          => $this->data['locale_slug'],
-				'original_permalink'   => $this->data['permalink'],
+				'original_permalink'   => $this->data['original_permalink'],
 				'original_id'          => $this->data['original_id'],
 				'project'              => $this->data['project'],
 				'translation_set_slug' => $this->data['translation_set_slug'],

--- a/helpers/helper-translation-discussion.php
+++ b/helpers/helper-translation-discussion.php
@@ -29,7 +29,15 @@ class Helper_Translation_Discussion extends GP_Translation_Helper {
 	 * @since 0.0.1
 	 * @var bool
 	 */
-	public $has_async_content = false;
+	public $has_async_content = true;
+
+	/**
+	 * Indicates whether the helper should be loaded inline.
+	 *
+	 * @since 0.0.2
+	 * @var bool
+	 */
+	public $load_inline = true;
 
 	/**
 	 * The post type used to store the comments.
@@ -85,6 +93,7 @@ class Helper_Translation_Discussion extends GP_Translation_Helper {
 		add_filter( 'user_has_cap', array( $this, 'give_user_read_cap' ), 10, 3 );
 		add_filter( 'post_type_link', array( $this, 'rewrite_original_post_type_permalink' ), 10, 2 );
 		add_filter( 'comment_reply_link', array( $this, 'comment_reply_link' ), 10, 4 );
+		add_filter( 'wp_ajax_create_shadow_post', array( $this, 'ajax_create_shadow_post' ) );
 	}
 
 	/**
@@ -287,11 +296,15 @@ class Helper_Translation_Discussion extends GP_Translation_Helper {
 	 *
 	 * @since 0.0.1
 	 *
-	 * @param int $post_id  The post ID.
+	 * @param $post_id  The post ID.
 	 *
 	 * @return false|string
 	 */
-	public static function get_original_from_post_id( int $post_id ) {
+	public static function get_original_from_post_id( $post_id ) {
+		if ( self::is_temporary_post_id( $post_id ) ) {
+			return self::get_original_id_from_temporary_post_id( $post_id );
+		}
+
 		$terms = wp_get_object_terms( $post_id, self::LINK_TAXONOMY, array( 'number' => 1 ) );
 		if ( empty( $terms ) ) {
 			return false;
@@ -301,18 +314,89 @@ class Helper_Translation_Discussion extends GP_Translation_Helper {
 	}
 
 	/**
+	 * Indicates whether the post id is a real one or a temporary one.
+	 *
+	 * @since 0.0.2
+	 *
+	 * @param int|string $post_id The post ID.
+	 *
+	 * @return bool
+	 */
+	public static function is_temporary_post_id( $post_id ) {
+		return self::get_original_id_from_temporary_post_id( $post_id ) > 0;
+	}
+
+	/**
+	 * Extract the original_id from the temporary post_id.
+	 *
+	 * @param      int|string $post_id The post ID.
+	 *
+	 * @return     int|null The original_id or null if the post_id is not a temporary one.
+	 */
+	public static function get_original_id_from_temporary_post_id( $post_id ) {
+		if ( self::POST_TYPE !== substr( $post_id, 0, strlen( self::POST_TYPE ) ) ) {
+			return null;
+		}
+		$original_id = substr( $post_id, strlen( self::POST_TYPE ) );
+		if ( is_numeric( $original_id ) && $original_id > 0 ) {
+			return intval( $original_id );
+		}
+
+		return null;
+	}
+
+	/**
+	 * Gets the post id of the shadow post and ensure its or create shadow post identifier.
+	 *
+	 * @param      int $original_id  The original identifier
+	 *
+	 * @return     <type>  The or create shadow post identifier.
+	 */
+	public static function get_or_create_shadow_post_id( int $original_id ) {
+		return self::get_shadow_post_id( $original_id, true );
+	}
+
+	/**
+	 * Get a Gth_Temporary_Post or a WP_Post, depending on the given post_id.
+	 *
+	 * @param      int|string $post_id  The post ID (could be a temporary one).
+	 *
+	 * @return     WP_Post|Gth_Temporary_Post  An object for use in wp_list_comments.
+	 */
+	public static function maybe_get_temporary_post( $post_id ) {
+		if ( self::is_temporary_post_id( $post_id ) ) {
+			return new Gth_Temporary_Post( $post_id );
+		}
+
+		return get_post( $post_id );
+	}
+
+	/**
 	 * Gets the post id for the comments and stores it in the cache.
 	 *
 	 * @since 0.0.1
 	 *
-	 * @param int $original_id  The original id for the string to translate. E.g. "2440".
+	 * @param int  $original_id  The original id for the string to translate. E.g. "2440".
+	 * @param bool $create       Whether to create a post if it doesn't exist.
 	 *
 	 * @return int|WP_Error
 	 */
-	public static function get_shadow_post( int $original_id ) {
+	public static function get_shadow_post_id( int $original_id, $create = false ) {
 		$cache_key = self::LINK_TAXONOMY . '_' . $original_id;
 
-		if ( true || false === ( $post_id = wp_cache_get( $cache_key ) ) ) {
+		$post_id = wp_cache_get( $cache_key );
+		if ( false !== $post_id ) {
+			// Something was found in the cache.
+
+			if ( self::is_temporary_post_id( $post_id ) && $create ) {
+				// a fake post_id was stored in the cache but we need to create an entry.
+				// Let's pretend a cache fail, so that we get a chance to create an entry unless one already exists.
+				$post_id = false;
+			}
+		}
+
+		if ( 'production' !== wp_get_environment_type() || false === $post_id ) {
+			$post_id  = null;
 			$gp_posts = get_posts(
 				array(
 					'tax_query'        => array(
@@ -330,8 +414,8 @@ class Helper_Translation_Discussion extends GP_Translation_Helper {
 			);
 
 			if ( ! empty( $gp_posts ) ) {
-						$post_id = $gp_posts[0]->ID;
-			} else {
+				$post_id = $gp_posts[0]->ID;
+			} elseif ( $create ) {
 				$post_id = wp_insert_post(
 					array(
 						'post_type'      => self::POST_TYPE,
@@ -343,6 +427,8 @@ class Helper_Translation_Discussion extends GP_Translation_Helper {
 						'comment_status' => 'open',
 					)
 				);
+			} else {
+				$post_id = self::POST_TYPE . strval( $original_id );
 			}
 		}
 
@@ -358,9 +444,14 @@ class Helper_Translation_Discussion extends GP_Translation_Helper {
 	 * @return array
 	 */
 	public function get_async_content(): array {
+		$post_id = self::get_shadow_post_id( $this->data['original_id'] );
+		if ( self::is_temporary_post_id( $post_id ) ) {
+			return array();
+		}
+
 		return get_comments(
 			array(
-				'post_id'            => self::get_shadow_post( $this->data['original_id'] ),
+				'post_id'            => $post_id,
 				'status'             => 'approve',
 				'type'               => 'comment',
 				'include_unapproved' => array( get_current_user_id() ),
@@ -378,6 +469,8 @@ class Helper_Translation_Discussion extends GP_Translation_Helper {
 	 * @return false|string
 	 */
 	public function async_output_callback( array $comments ) {
+		$this->set_count( $comments );
+
 		// Remove comment likes for now (or forever :) ).
 		remove_filter( 'comment_text', 'comment_like_button', 12 );
 
@@ -424,11 +517,13 @@ class Helper_Translation_Discussion extends GP_Translation_Helper {
 
 		remove_action( 'comment_form_top', 'rosetta_comment_form_support_hint' );
 
+		$post = self::maybe_get_temporary_post( self::get_shadow_post_id( $this->data['original_id'] ) );
+
 		$output = gp_tmpl_get_output(
 			'translation-discussion-comments',
 			array(
 				'comments'             => $comments,
-				'post_id'              => self::get_shadow_post( $this->data['original_id'] ),
+				'post'                 => $post,
 				'translation_id'       => isset( $this->data['translation_id'] ) ? $this->data['translation_id'] : null,
 				'locale_slug'          => $this->data['locale_slug'],
 				'original_permalink'   => $this->data['original_permalink'],
@@ -584,6 +679,21 @@ class Helper_Translation_Discussion extends GP_Translation_Helper {
 			$args['reply_text']
 		);
 		return $args['before'] . $link . $args['after'];
+	}
+
+	/**
+	 * Ajax callback for creating the shadow post.
+	 *
+	 * Returns the $post_id back to JS.
+	 *
+	 * @since 0.0.2
+	 */
+	public function ajax_create_shadow_post() {
+		check_ajax_referer( 'wp_rest', 'nonce' );
+
+		$original_id = self::get_original_id_from_temporary_post_id( $_POST['data']['post'] );
+		$post_id     = self::get_or_create_shadow_post_id( $original_id );
+		wp_send_json_success( $post_id );
 	}
 
 	/**

--- a/helpers/helper-translation-discussion.php
+++ b/helpers/helper-translation-discussion.php
@@ -387,6 +387,23 @@ class Helper_Translation_Discussion extends GP_Translation_Helper {
 		// Disable subscribe to comments for now.
 		add_filter( 'option_stc_disabled', '__return_true' );
 
+		// Link comment author to their profile.
+		add_filter(
+			'get_comment_author_link',
+			function( $return, $author, $comment_id ) {
+				$comment = get_comment( $comment_id );
+				if ( ! empty( $comment->user_id ) ) {
+					$user = get_userdata( $comment->user_id );
+					if ( $user ) {
+						return gp_link_user( $user );
+					}
+				}
+				return $return;
+			},
+			10,
+			3
+		);
+
 		add_filter(
 			'comment_form_logged_in',
 			function( $logged_in_as, $commenter, $user_identity ) {

--- a/includes/class-gp-route-translation-helpers.php
+++ b/includes/class-gp-route-translation-helpers.php
@@ -153,7 +153,7 @@ class GP_Route_Translation_Helpers extends GP_Route {
 	 */
 	public function get_translation_helper_sections( $data ) {
 		$sections = array();
-		foreach ( $this->helpers as $translation_helper ) {
+		foreach ( $this->helpers as $helper => $translation_helper ) {
 			$translation_helper->set_data( $data );
 
 			if ( ! $translation_helper->activate() ) {
@@ -167,6 +167,9 @@ class GP_Route_Translation_Helpers extends GP_Route {
 				'id'                => $translation_helper->get_div_id(),
 				'priority'          => $translation_helper->get_priority(),
 				'has_async_content' => $translation_helper->has_async_content(),
+				'count'             => $translation_helper->get_count(),
+				'load_inline'       => $translation_helper->load_inline(),
+				'helper'            => $helper,
 			);
 		}
 
@@ -228,10 +231,17 @@ class GP_Route_Translation_Helpers extends GP_Route {
 			'project'              => $project,
 		);
 
-		$single_helper = gp_get( 'helper' );
-		$helpers       = $this->helpers;
-		if ( isset( $this->helpers[ $single_helper ] ) ) {
-			$helpers = array( $this->helpers[ $single_helper ] );
+		$selected = gp_get( 'helpers' );
+		if ( ! empty( $selected ) ) {
+			$helpers = array_filter(
+				$this->helpers,
+				function ( $key ) use ( $selected ) {
+					return in_array( $key, (array) $selected, true );
+				},
+				ARRAY_FILTER_USE_KEY
+			);
+		} else {
+			$helpers = $this->helpers;
 		}
 
 		$sections = array();

--- a/includes/class-gp-translation-helpers.php
+++ b/includes/class-gp-translation-helpers.php
@@ -77,7 +77,7 @@ class GP_Translation_Helpers {
 		add_filter( 'gp_translation_row_template_more_links', array( $this, 'translation_row_template_more_links' ), 10, 5 );
 		add_filter( 'preprocess_comment', array( $this, 'preprocess_comment' ) );
 
-		//Proof of concept: changing occurrences of `rejected` to `changes requested` and `reject` to `request changes`
+		// Proof of concept: changing occurrences of `rejected` to `changes requested` and `reject` to `request changes`
 		WPorg_GlotPress_Customization::replace_with_changes_requested();
 
 		$this->helpers = self::load_helpers();

--- a/includes/class-gp-translation-helpers.php
+++ b/includes/class-gp-translation-helpers.php
@@ -77,6 +77,9 @@ class GP_Translation_Helpers {
 		add_filter( 'gp_translation_row_template_more_links', array( $this, 'translation_row_template_more_links' ), 10, 5 );
 		add_filter( 'preprocess_comment', array( $this, 'preprocess_comment' ) );
 
+		//Proof of concept: changing occurrences of `rejected` to `changes requested` and `reject` to `request changes`
+		WPorg_GlotPress_Customization::replace_with_changes_requested();
+
 		$this->helpers = self::load_helpers();
 	}
 

--- a/includes/class-gth-temporary-post.php
+++ b/includes/class-gth-temporary-post.php
@@ -1,0 +1,14 @@
+<?php
+
+class Gth_Temporary_Post {
+	public $ID;
+	public $comments_open = 'open';
+	public function __construct( $post_id ) {
+		$this->ID = $post_id;
+	}
+
+	public function __toString() {
+		return strval( $this->ID );
+	}
+}
+

--- a/includes/class-wporg-customization.php
+++ b/includes/class-wporg-customization.php
@@ -17,4 +17,34 @@ class WPorg_GlotPress_Customization {
 		wp_register_style( 'wporg-translation-discussion-css', plugins_url( '/../helpers-assets/css/wporg-translation-discussion.css', __FILE__ ), array(), '0.0.1' );
 		gp_enqueue_style( 'wporg-translation-discussion-css' );
 	}
+
+    /**
+	 * Activates the filters that replaces 'rejected' with 'changes requested'
+     * and 'Reject' to 'Request changes'
+	 *
+	 * @since 0.0.2
+	 *
+	 * @return void
+	 */
+    public static function replace_with_changes_requested(){
+        add_filter('gettext_glotpress', function( $translation, $text ) {
+			if ($text == 'Rejected'){
+				return 'Changes requested';
+			}
+            if ($text == 'Reject'){
+				return 'Request changes';
+			}
+			return $translation;
+		}, 10, 2); 
+
+        add_filter('gettext_with_context_glotpress', function( $translation, $text ) {
+			if ($text == 'rejected'){
+				return 'changes requested';
+			}
+            if ($text == 'Reject'){
+				return 'Request changes';
+			}
+			return $translation;
+		},10, 2);
+    }
 }

--- a/includes/class-wporg-customization.php
+++ b/includes/class-wporg-customization.php
@@ -20,31 +20,41 @@ class WPorg_GlotPress_Customization {
 
     /**
 	 * Activates the filters that replaces 'rejected' with 'changes requested'
-     * and 'Reject' to 'Request changes'
+	 * and 'Reject' to 'Request changes'
 	 *
 	 * @since 0.0.2
 	 *
 	 * @return void
 	 */
-    public static function replace_with_changes_requested(){
-        add_filter('gettext_glotpress', function( $translation, $text ) {
-			if ($text == 'Rejected'){
-				return 'Changes requested';
-			}
-            if ($text == 'Reject'){
-				return 'Request changes';
-			}
-			return $translation;
-		}, 10, 2); 
+	public static function replace_with_changes_requested() {
+		add_filter(
+			'gettext_glotpress',
+			function( $translation, $text ) {
+				if ( $text == 'Rejected' ) {
+					return 'Changes requested';
+				}
+				if ( $text == 'Reject' ) {
+					return 'Request changes';
+				}
+				return $translation;
+			},
+			10,
+			2
+		);
 
-        add_filter('gettext_with_context_glotpress', function( $translation, $text ) {
-			if ($text == 'rejected'){
-				return 'changes requested';
-			}
-            if ($text == 'Reject'){
-				return 'Request changes';
-			}
-			return $translation;
-		},10, 2);
-    }
+		add_filter(
+			'gettext_with_context_glotpress',
+			function( $translation, $text ) {
+				if ( $text == 'rejected' ) {
+					return 'changes requested';
+				}
+				if ( $text == 'Reject' ) {
+					return 'Request changes';
+				}
+				return $translation;
+			},
+			10,
+			2
+		);
+	}
 }

--- a/includes/class-wporg-customization.php
+++ b/includes/class-wporg-customization.php
@@ -30,10 +30,10 @@ class WPorg_GlotPress_Customization {
 		add_filter(
 			'gettext_glotpress',
 			function( $translation, $text ) {
-				if ( $text == 'Rejected' ) {
+				if ( 'Rejected' === $text ) {
 					return 'Changes requested';
 				}
-				if ( $text == 'Reject' ) {
+				if ( 'Reject' === $text ) {
 					return 'Request changes';
 				}
 				return $translation;
@@ -45,10 +45,10 @@ class WPorg_GlotPress_Customization {
 		add_filter(
 			'gettext_with_context_glotpress',
 			function( $translation, $text ) {
-				if ( $text == 'rejected' ) {
+				if ( 'rejected' === $text ) {
 					return 'changes requested';
 				}
-				if ( $text == 'Reject' ) {
+				if ( 'Reject' === $text ) {
 					return 'Request changes';
 				}
 				return $translation;

--- a/includes/class-wporg-customization.php
+++ b/includes/class-wporg-customization.php
@@ -36,6 +36,9 @@ class WPorg_GlotPress_Customization {
 				if ( 'Reject' === $text ) {
 					return 'Request changes';
 				}
+                if ( 'Rejected by:' === $text ) {
+					return 'Changes requested by:';
+				}
 				return $translation;
 			},
 			10,
@@ -50,6 +53,9 @@ class WPorg_GlotPress_Customization {
 				}
 				if ( 'Reject' === $text ) {
 					return 'Request changes';
+				}
+                if ( 'Rejected by:' === $text ) {
+					return 'Changes requested by:';
 				}
 				return $translation;
 			},

--- a/includes/class-wporg-customization.php
+++ b/includes/class-wporg-customization.php
@@ -36,7 +36,7 @@ class WPorg_GlotPress_Customization {
 				if ( 'Reject' === $text ) {
 					return 'Request changes';
 				}
-                if ( 'Rejected by:' === $text ) {
+				if ( 'Rejected by:' === $text ) {
 					return 'Changes requested by:';
 				}
 				return $translation;
@@ -54,7 +54,7 @@ class WPorg_GlotPress_Customization {
 				if ( 'Reject' === $text ) {
 					return 'Request changes';
 				}
-                if ( 'Rejected by:' === $text ) {
+				if ( 'Rejected by:' === $text ) {
 					return 'Changes requested by:';
 				}
 				return $translation;

--- a/includes/class-wporg-customization.php
+++ b/includes/class-wporg-customization.php
@@ -18,7 +18,7 @@ class WPorg_GlotPress_Customization {
 		gp_enqueue_style( 'wporg-translation-discussion-css' );
 	}
 
-    /**
+	/**
 	 * Activates the filters that replaces 'rejected' with 'changes requested'
 	 * and 'Reject' to 'Request changes'
 	 *
@@ -30,14 +30,11 @@ class WPorg_GlotPress_Customization {
 		add_filter(
 			'gettext_glotpress',
 			function( $translation, $text ) {
-				if ( 'Rejected' === $text ) {
+				if ( $text == 'Rejected' ) {
 					return 'Changes requested';
 				}
-				if ( 'Reject' === $text ) {
+				if ( $text == 'Reject' ) {
 					return 'Request changes';
-				}
-				if ( 'Rejected by:' === $text ) {
-					return 'Changes requested by:';
 				}
 				return $translation;
 			},
@@ -48,14 +45,11 @@ class WPorg_GlotPress_Customization {
 		add_filter(
 			'gettext_with_context_glotpress',
 			function( $translation, $text ) {
-				if ( 'rejected' === $text ) {
+				if ( $text == 'rejected' ) {
 					return 'changes requested';
 				}
-				if ( 'Reject' === $text ) {
+				if ( $text == 'Reject' ) {
 					return 'Request changes';
-				}
-				if ( 'Rejected by:' === $text ) {
-					return 'Changes requested by:';
 				}
 				return $translation;
 			},

--- a/includes/class-wporg-notifications.php
+++ b/includes/class-wporg-notifications.php
@@ -95,7 +95,7 @@ class WPorg_GlotPress_Notifications {
 		$parent_comments        = GP_Notifications::get_parent_comments( $comment->comment_parent );
 		$emails_from_the_thread = GP_Notifications::get_commenters_email_addresses( $parent_comments );
 		// Set the email addresses array as empty if one GTE/PTE/CLPTE has a comment in the thread.
-		if ( ! empty( array_intersect( $email_addresses, $emails_from_the_thread, true ) ) || in_array( $comment->comment_author_email, $email_addresses, true ) ) {
+		if ( ! empty( array_intersect( $email_addresses, $emails_from_the_thread ) ) || in_array( $comment->comment_author_email, $email_addresses, true ) ) {
 			return array();
 		}
 		return $email_addresses;

--- a/js/reject-feedback.js
+++ b/js/reject-feedback.js
@@ -3,6 +3,8 @@
 	$( document ).ready(
 		function() {
 			var rowIds = [];
+			var translationIds = [];
+			var originalIds = [];
 			var feedbackForm = '<details><summary class="feedback-summary">Give feedback</summary>' +
 			'<div id="feedback-form">' +
 			'<form>' +
@@ -47,24 +49,37 @@
 					$( this ).prop( 'checked', false );
 					return null;
 				} ).get();
+
+				rowIds.forEach( function( rowId ) {
+					var originalId = $gp.editor.original_id_from_row_id( rowId );
+					var translationId = $gp.editor.translation_id_from_row_id( rowId );
+
+					if ( originalId && translationId ) {
+						originalIds.push( originalId );
+						translationIds.push( translationId );
+					}
+				} );
+
 				if ( $( 'select[name="bulk[action]"]' ).val() === 'reject' ) {
 					e.preventDefault();
 					e.stopImmediatePropagation();
+					if ( ! translationIds.length ) {
+						$( 'form.filters-toolbar.bulk-actions' ).submit();
+						return;
+					}
 
+					// eslint-disable-next-line no-undef
 					tb_show( 'Reject with Feedback', '#TB_inline?inlineId=reject-feedback-form' );
 				}
 			} );
 
 			$( 'body' ).on( 'click', '#modal-reject-btn', function( e ) {
-				var rowIdsArray = rowIds.split( ',' );
-				var translationIds = [];
-				var originalIds = [];
 				var comment = '';
 				var rejectReason = [];
 				var rejectData = {};
 				var form = $( this ).closest( 'form' );
 
-				rowIdsArray.forEach( function( rowId ) {
+				rowIds.forEach( function( rowId ) {
 					var originalId = $gp.editor.original_id_from_row_id( rowId );
 					var translationId = $gp.editor.translation_id_from_row_id( rowId );
 

--- a/js/reject-feedback.js
+++ b/js/reject-feedback.js
@@ -79,16 +79,6 @@
 				var rejectData = {};
 				var form = $( this ).closest( 'form' );
 
-				rowIds.forEach( function( rowId ) {
-					var originalId = $gp.editor.original_id_from_row_id( rowId );
-					var translationId = $gp.editor.translation_id_from_row_id( rowId );
-
-					if ( originalId && translationId ) {
-						originalIds.push( originalId );
-						translationIds.push( translationId );
-					}
-				} );
-
 				form.find( 'input[name="modal_feedback_reason"]:checked' ).each(
 					function() {
 						rejectReason.push( this.value );

--- a/js/reject-feedback.js
+++ b/js/reject-feedback.js
@@ -56,6 +56,7 @@
 			} );
 
 			$( 'body' ).on( 'click', '#modal-reject-btn', function( e ) {
+				var rowIdsArray = rowIds.split( ',' );
 				var translationIds = [];
 				var originalIds = [];
 				var comment = '';
@@ -63,7 +64,7 @@
 				var rejectData = {};
 				var form = $( this ).closest( 'form' );
 
-				rowIds.forEach( function( rowId ) {
+				rowIdsArray.forEach( function( rowId ) {
 					var originalId = $gp.editor.original_id_from_row_id( rowId );
 					var translationId = $gp.editor.translation_id_from_row_id( rowId );
 
@@ -82,7 +83,7 @@
 				comment = form.find( 'textarea[name="modal_feedback_comment"]' ).val();
 
 				if ( ( ! comment.trim().length && ! rejectReason.length ) || ( ! translationIds.length || ! originalIds.length ) ) {
-					$( 'form#bulk-actions-toolbar-top' ).submit();
+					$( 'form.filters-toolbar.bulk-actions' ).submit();
 				}
 
 				rejectData.locale_slug = $gp_reject_feedback_settings.locale_slug;

--- a/js/reject-feedback.js
+++ b/js/reject-feedback.js
@@ -64,7 +64,7 @@
 					e.preventDefault();
 					e.stopImmediatePropagation();
 					if ( ! translationIds.length ) {
-						$( 'form.filters-toolbar.bulk-actions' ).submit();
+						$( 'form.filters-toolbar.bulk-actions, form#bulk-actions-toolbar-top' ).submit();
 						return;
 					}
 
@@ -98,7 +98,7 @@
 				comment = form.find( 'textarea[name="modal_feedback_comment"]' ).val();
 
 				if ( ( ! comment.trim().length && ! rejectReason.length ) || ( ! translationIds.length || ! originalIds.length ) ) {
-					$( 'form.filters-toolbar.bulk-actions' ).submit();
+					$( 'form.filters-toolbar.bulk-actions, form#bulk-actions-toolbar-top' ).submit();
 				}
 
 				rejectData.locale_slug = $gp_reject_feedback_settings.locale_slug;
@@ -166,7 +166,7 @@
 		).done(
 			function() {
 				if ( rejectData.is_bulk_reject ) {
-					$( 'form#bulk-actions-toolbar-top' ).submit();
+					$( 'form.filters-toolbar.bulk-actions, form#bulk-actions-toolbar-top' ).submit();
 				} else {
 					$gp.editor.set_status( button, 'rejected' );
 					div.find( 'input[name="feedback_reason"]' ).prop( 'checked', false );

--- a/js/translation-helpers.js
+++ b/js/translation-helpers.js
@@ -1,18 +1,19 @@
-$gp.translation_helpers = ( // eslint-disable-line no-undef
+/* global $gp, window */
+$gp.translation_helpers = (
 	function( $ ) {
 		return {
 			init: function( table, fetchNow ) {
-				$gp.translation_helpers.table = table; // eslint-disable-line no-undef
-				$gp.translation_helpers.install_hooks(); // eslint-disable-line no-undef
+				$gp.translation_helpers.table = table;
+				$gp.translation_helpers.install_hooks();
 				if ( fetchNow ) {
-					$gp.translation_helpers.fetch( false, $( '.translations' ) ); // eslint-disable-line no-undef
+					$gp.translation_helpers.fetch( false, $( '.translations' ) );
 				}
 			},
 			install_hooks: function() {
-				$( $gp.translation_helpers.table ) // eslint-disable-line no-undef
-					.on( 'beforeShow', '.editor', $gp.translation_helpers.hooks.initial_fetch ) // eslint-disable-line no-undef
-					.on( 'click', '.helpers-tabs li', $gp.translation_helpers.hooks.tab_select ) // eslint-disable-line no-undef
-					.on( 'click', 'a.comment-reply-link', $gp.translation_helpers.hooks.reply_comment_form ); // eslint-disable-line no-undef
+				$( $gp.translation_helpers.table )
+					.on( 'beforeShow', '.editor', $gp.translation_helpers.hooks.initial_fetch )
+					.on( 'click', '.helpers-tabs li', $gp.translation_helpers.hooks.tab_select )
+					.on( 'click', 'a.comment-reply-link', $gp.translation_helpers.hooks.reply_comment_form );
 			},
 			initial_fetch: function( $element ) {
 				var $helpers = $element.find( '.translation-helpers' );
@@ -21,7 +22,7 @@ $gp.translation_helpers = ( // eslint-disable-line no-undef
 					return;
 				}
 
-				$gp.translation_helpers.fetch( false, $element ); // eslint-disable-line no-undef
+				$gp.translation_helpers.fetch( false, $element );
 			},
 			fetch: function( which, $element ) {
 				var $helpers;
@@ -40,7 +41,9 @@ $gp.translation_helpers = ( // eslint-disable-line no-undef
 				}
 				requestUrl = requestUrl + '&replytocom=' + replytocom;
 
-				$helpers.addClass( 'loading' );
+				if ( $helpers.find( 'div:first .async-content' ).length ) {
+					$helpers.addClass( 'loading' );
+				}
 
 				$.getJSON(
 					requestUrl,
@@ -75,16 +78,16 @@ $gp.translation_helpers = ( // eslint-disable-line no-undef
 			},
 			hooks: {
 				initial_fetch: function() {
-					$gp.translation_helpers.initial_fetch( $( this ) ); // eslint-disable-line no-undef
+					$gp.translation_helpers.initial_fetch( $( this ) );
 					return false;
 				},
 				tab_select: function() {
-					$gp.translation_helpers.tab_select( $( this ) ); // eslint-disable-line no-undef
+					$gp.translation_helpers.tab_select( $( this ) );
 					return false;
 				},
 				reply_comment_form: function( event ) {
 					event.preventDefault();
-					$gp.translation_helpers.reply_comment_form( $( this ) ); // eslint-disable-line no-undef
+					$gp.translation_helpers.reply_comment_form( $( this ) );
 					return false;
 				},
 			},
@@ -93,10 +96,10 @@ $gp.translation_helpers = ( // eslint-disable-line no-undef
 );
 
 jQuery( function( $ ) {
-	$gp.translation_helpers.init( $( '.translations' ), true ); // eslint-disable-line no-undef
-	if ( typeof window.newShowFunctionAttached === 'undefined' ) { // eslint-disable-line
-		window.newShowFunctionAttached = true; // eslint-disable-line
-		var _oldShow = $.fn.show; // eslint-disable-line vars-on-top
+	var _oldShow = $.fn.show;
+	$gp.translation_helpers.init( $( '.translations' ), true );
+	if ( typeof window.newShowFunctionAttached === 'undefined' ) {
+		window.newShowFunctionAttached = true;
 		$.fn.show = function( speed, oldCallback ) {
 			return $( this ).each( function() {
 				var obj = $( this ),

--- a/js/translation-helpers.js
+++ b/js/translation-helpers.js
@@ -37,11 +37,15 @@ $gp.translation_helpers = (
 				var requestUrl = $gp_translation_helpers_settings.th_url + originalId + '?nohc'; // eslint-disable-line
 
 				if ( which ) {
-					requestUrl = requestUrl + '&helper=' + which;
+					requestUrl = requestUrl + '&helpers[]=' + which;
+				} else {
+					$helpers.find( 'div.helper:not(.loaded) ' ).each( function() {
+						requestUrl = requestUrl + '&helpers[]=' + $( this ).data( 'helper' );
+					} );
 				}
 				requestUrl = requestUrl + '&replytocom=' + replytocom;
 
-				if ( $helpers.find( 'div:first .async-content' ).length ) {
+				if ( $helpers.find( 'div:first' ).is( ':not(.loaded)' ) ) {
 					$helpers.addClass( 'loading' );
 				}
 

--- a/templates/original-permalink.php
+++ b/templates/original-permalink.php
@@ -128,7 +128,7 @@ gp_tmpl_header();
 			$is_first_class = 'current';
 			foreach ( $sections as $section ) {
 				// TODO: printf.
-				echo "<li class='{$is_first_class}' data-tab='{$section['id']}'>" . esc_html( $section['title'] ) . '<span class="count"></span></li>'; // WPCS: XSS OK.
+				echo "<li class='{$is_first_class}' data-tab='{$section['id']}'>" . esc_html( $section['title'] ) . '<span class="count">' . esc_html( $section['count'] ? ( '(' . $section['count'] . ')' ) : '' ) . '</span></li>'; // phpcs:ignore: XSS OK.
 				$is_first_class = '';
 			}
 			?>
@@ -137,12 +137,15 @@ gp_tmpl_header();
 	<?php
 	$is_first_class = 'current';
 	foreach ( $sections as $section ) {
-		printf( '<div class="%s helper %s" id="%s">', esc_attr( $section['classname'] ), esc_attr( $is_first_class ), esc_attr( $section['id'] ) );
+		printf( '<div class="%s helper %s %s" id="%s" data-helper="%s">', esc_attr( $section['classname'] ), esc_attr( $is_first_class ), $section['load_inline'] ? 'loaded' : '', esc_attr( $section['id'] ), esc_attr( $section['helper'] ) );
 		if ( $section['has_async_content'] ) {
-			echo '<div class="async-content"></div>';
+			echo '<div class="async-content">';
 		}
 
-		echo $section['content']; // WPCS: XSS OK.
+		echo $section['content']; // phpcs:ignore XSS OK.
+		if ( $section['has_async_content'] ) {
+			echo '</div>';
+		}
 		echo '</div>';
 		$is_first_class = '';
 	}

--- a/templates/original-permalink.php
+++ b/templates/original-permalink.php
@@ -139,17 +139,10 @@ gp_tmpl_header();
 	foreach ( $sections as $section ) {
 		printf( '<div class="%s helper %s" id="%s">', esc_attr( $section['classname'] ), esc_attr( $is_first_class ), esc_attr( $section['id'] ) );
 		if ( $section['has_async_content'] ) {
-			if ( 'helper-translation-discussion' == $section['classname'] ) {
-				echo '<div class="async-content">';
-				gp_tmpl_load( 'translation-discussion-comments', get_defined_vars(), dirname( dirname( __FILE__ ) ) . '/helpers-assets/templates' );
-				echo '</div>';
-				$section['content'] = '';
-			} else {
-				echo '<div class="async-content"></div>';
-			}
+			echo '<div class="async-content"></div>';
 		}
 
-		echo wp_kses_post( $section['content'] );
+		echo $section['content']; // WPCS: XSS OK.
 		echo '</div>';
 		$is_first_class = '';
 	}

--- a/templates/translation-helpers.php
+++ b/templates/translation-helpers.php
@@ -15,10 +15,10 @@
 	$is_first_class = 'current';
 	foreach ( $sections as $section ) {
 		printf( '<div class="%s helper %s" id="%s">', esc_attr( $section['classname'] ), esc_attr( $is_first_class ), esc_attr( $section['id'] ) );
-		if ( $section['has_async_content'] ) {
+		if ( ! $section['has_async_content'] ) {
 			echo '<div class="async-content"></div>';
 		}
-		echo esc_html( $section['content'] );
+		echo $section['content']; // phpcs:ignore XSS OK.
 		echo '</div>';
 		$is_first_class = '';
 	}


### PR DESCRIPTION
## Problem

We'd like to set a more positive tone when starting conversations. 
Here's what we have now;
<img width="289" alt="Screenshot 2022-04-26 at 07 33 58" src="https://user-images.githubusercontent.com/2834132/165237497-9d1eb8ea-1371-4ff1-8da7-dec157e72c20.png">
<img width="947" alt="Screenshot 2022-04-26 at 07 35 24" src="https://user-images.githubusercontent.com/2834132/165237570-05519666-2fbf-4cc3-9de8-4bbee1fc41a1.png">
<img width="951" alt="Screenshot 2022-04-26 at 07 35 59" src="https://user-images.githubusercontent.com/2834132/165237595-14e4d2e2-2421-4d23-b971-844943cc163c.png">
<img width="715" alt="Screenshot 2022-04-26 at 07 34 49" src="https://user-images.githubusercontent.com/2834132/165237621-f1a6b0fb-4e6e-44a8-a25a-b39f690135bd.png">

## Solution

Rename Reject to Request Changes. This should be only on translate.wordpress.org, so please add this to the .org side of the plugin. It still needs to be coordinated with the .org Polyglots but the screenshots can be a conversation starter.

### Screenshots
![request-changes](https://user-images.githubusercontent.com/203408/163956970-0511814d-ff6e-4a22-aa1a-57abe5e06497.png)

![changes-requested](https://user-images.githubusercontent.com/203408/163956768-113d8298-78f4-4455-8b88-5f24236074a0.png)