### PR TITLE
Correct the user's URL

### DIFF
--- a/helpers/helper-translation-discussion.php
+++ b/helpers/helper-translation-discussion.php
@@ -387,15 +387,6 @@ class Helper_Translation_Discussion extends GP_Translation_Helper {
 		// Disable subscribe to comments for now.
 		add_filter( 'option_stc_disabled', '__return_true' );
 
-		// Link comment author to WordPress.org profile.
-		add_filter(
-			'get_comment_author_link',
-			function() {
-					$comment_author = get_comment_author();
-					return '<a href="https://profiles.wordpress.org/' . $comment_author . '">' . $comment_author . '</a>';
-			}
-		);
-
 		add_filter(
 			'comment_form_logged_in',
 			function( $logged_in_as, $commenter, $user_identity ) {

--- a/helpers/helper-translation-discussion.php
+++ b/helpers/helper-translation-discussion.php
@@ -387,6 +387,23 @@ class Helper_Translation_Discussion extends GP_Translation_Helper {
 		// Disable subscribe to comments for now.
 		add_filter( 'option_stc_disabled', '__return_true' );
 
+		// Link comment author to their profile.
+		add_filter(
+			'get_comment_author_link',
+			function( $return, $author, $comment_id ) {
+				$comment = get_comment( $comment_id );
+				if ( ! empty( $comment->user_id ) ) {
+					$user = get_userdata( $comment->user_id );
+					if ( $user ) {
+						return gp_link_user( $user );
+					}
+				}
+				return $return;
+			},
+			10,
+			3
+		);
+
 		add_filter(
 			'comment_form_logged_in',
 			function( $logged_in_as, $commenter, $user_identity ) {


### PR DESCRIPTION
### Problem

The link to the user profile is incorrect, because we are using the `$comment_author` in the URL.

![incorrect-link](https://user-images.githubusercontent.com/1667814/165918735-f4991310-0a09-49f0-bf5f-fb7c9729f67c.jpg)

### Solution

Remove the filter that was causing the problem.

### Testing instructions

Push the mouse over the link to check that the new URL is correct. Click on the link to go to the user profile.

![incorrect-link-2](https://user-images.githubusercontent.com/1667814/165919531-95f43bcd-110c-41b6-a40a-acb9feb86c1e.jpg)


