### PR TITLE
Notification on rejection

### DIFF
--- a/includes/class-gp-notifications.php
+++ b/includes/class-gp-notifications.php
@@ -116,6 +116,9 @@ class GP_Notifications {
 		$translation_id = $comment_meta['translation_id'];
 		$translation    = GP::$translation->get( $translation_id );
 		$translator     = get_user_by( 'id', $translation->user_id_last_modified );
+		if ( false === $translator ) {
+			$translator = get_user_by( 'id', $translation->user_id );
+		}
 		self::send_emails( $comment, $comment_meta, array( $translator->user_email ) );
 	}
 

--- a/includes/class-gp-notifications.php
+++ b/includes/class-gp-notifications.php
@@ -27,6 +27,9 @@ class GP_Notifications {
 				if ( ( '0' !== $comment->comment_parent ) ) { // Notify to the thread only if the comment is in a thread.
 					self::send_emails_to_thread_commenters( $comment, $comment_meta );
 				}
+				if ( ( '0' === $comment->comment_parent ) && array_key_exists( 'reject_reason', $comment_meta ) && ( ! empty( $comment_meta['reject_reason'] ) ) ) {  // Notify a rejection without parent comments.
+					self::send_rejection_email_to_translator( $comment, $comment_meta );
+				}
 				$root_comment      = self::get_root_comment_in_a_thread( $comment );
 				$root_comment_meta = get_comment_meta( $root_comment->comment_ID );
 				if ( array_key_exists( 'comment_topic', $root_comment_meta ) ) {
@@ -90,6 +93,23 @@ class GP_Notifications {
 		 */
 		$email_addresses = apply_filters( 'gp_notification_commenter_email_addresses', $email_addresses, $comment, $comment_meta );
 		self::send_emails( $comment, $comment_meta, $email_addresses );
+	}
+
+	/**
+	 * Sends the reject notification to the translator.
+	 *
+	 * @since 0.0.2
+	 *
+	 * @param WP_Comment $comment      The comment object.
+	 * @param array      $comment_meta The meta values for the comment.
+	 *
+	 * @return void
+	 */
+	public static function send_rejection_email_to_translator( WP_Comment $comment, array $comment_meta ) {
+		$translation_id = $comment_meta['translation_id'];
+		$translation    = GP::$translation->get( $translation_id );
+		$translator     = get_user_by( 'id', $translation->user_id_last_modified );
+		self::send_emails( $comment, $comment_meta, array( $translator->user_email ) );
 	}
 
 	/**

--- a/includes/class-gp-notifications.php
+++ b/includes/class-gp-notifications.php
@@ -9,6 +9,13 @@
  */
 class GP_Notifications {
 	/**
+	 * Stores the related comments to the first one when the validator makes a bulk rejection.
+	 *
+	 * @since 0.0.2
+	 * @var array
+	 */
+	private static array $related_comments = array();
+	/**
 	 * Sends notifications when a new comment in the discussion is stored using the WP REST API.
 	 *
 	 * @since 0.0.2
@@ -377,34 +384,63 @@ class GP_Notifications {
 				'a' => array( 'href' => array() ),
 			)
 		) . '<br/>';
+		if ( ! empty( self::$related_comments ) ) {
+			$output .= wp_kses(
+			/* translators: The number of different translations related with the comment. */
+				sprintf( __( 'This comment affects to <strong>%1$d different translations</strong>.', 'glotpress' ), count( self::$related_comments ) + 1 ),
+				array(
+					'a'      => array( 'href' => array() ),
+					'strong' => array(),
+				)
+			) . '<br/>';
+		}
 		$output .= '<br>';
 		$output .= esc_html__( 'It would be nice if you have some time to review this comment and reply to it if needed.', 'glotpress' );
 		$output .= '<br><br>';
-		$output .= '- ' . wp_kses(
+		if ( array_key_exists( 'locale', $comment_meta ) && ( ! empty( $comment_meta['locale'][0] ) ) ) {
+			/* translators: The translation locale for the comment. */
+			$output .= '- ' . wp_kses( sprintf( __( '<strong>Locale:</strong> %s', 'glotpress' ), $comment_meta['locale'][0] ), array( 'strong' => array() ) ) . '<br/>';
+		}
+		if ( empty( self::$related_comments ) ) { // Only show original and translation strings if we don't have related comments (bulk rejection).
+			/* translators: The original string to translate. */
+			$output .= '- ' . wp_kses( sprintf( __( '<strong>Original string:</strong> %s', 'glotpress' ), $original->singular ), array( 'strong' => array() ) ) . '<br/>';
+			if ( array_key_exists( 'translation_id', $comment_meta ) && $comment_meta['translation_id'][0] ) {
+				$translation_id = $comment_meta['translation_id'][0];
+				$translation    = GP::$translation->get( $translation_id );
+				// todo: add the plurals.
+				if ( ! is_null( $translation ) ) {
+					/* translators: The translation string. */
+					$output .= '- ' . wp_kses( sprintf( __( '<strong>Translation string:</strong> %s', 'glotpress' ), $translation->translation_0 ), array( 'strong' => array() ) ) . '<br/>';
+				}
+			}
+		}
+		/* translators: The comment made. */
+		$output .= '- ' . wp_kses( sprintf( __( '<strong>Comment:</strong> %s', 'glotpress' ), $comment->comment_content ), array( 'strong' => array() ) ) . '<br/>';
+		if ( empty( self::$related_comments ) ) {
+			$output .= '- ' . __( '<strong>Discussion URL:</strong>' ) . '<br/>';
+		} else {
+			$output .= '- ' . __( '<strong>Discussion URLs:</strong>' ) . '<br/>';
+		}
+		$output .= '&nbsp;&nbsp;&nbsp; - ' . wp_kses(
 			/* translators: The discussion URL where the user can find the comment. */
-			sprintf( __( '<strong>Discussion URL:</strong> <a href="%1$s">%1$s</a>', 'glotpress' ), $url ),
+			sprintf( __( '<a href="%1$s">%1$s</a>', 'glotpress' ), $url ),
 			array(
 				'strong' => array(),
 				'a'      => array( 'href' => array() ),
 			)
 		) . '<br/>';
-		if ( array_key_exists( 'locale', $comment_meta ) && ( ! empty( $comment_meta['locale'][0] ) ) ) {
-			/* translators: The translation locale for the comment. */
-			$output .= '- ' . wp_kses( sprintf( __( '<strong>Locale:</strong> %s', 'glotpress' ), $comment_meta['locale'][0] ), array( 'strong' => array() ) ) . '<br/>';
+		foreach ( self::$related_comments as $related_comment ) {
+			$original = self::get_original( $related_comment );
+			$url      = GP_Route_Translation_Helpers::get_permalink( $project->path, $original->id );
+			$output  .= '&nbsp;&nbsp;&nbsp; - ' . wp_kses(
+				/* translators: The discussion URL where the user can find the comment. */
+				sprintf( __( '<a href="%1$s">%1$s</a>', 'glotpress' ), $url ),
+				array(
+					'strong' => array(),
+					'a'      => array( 'href' => array() ),
+				)
+			) . '<br/>';
 		}
-		/* translators: The original string to translate. */
-		$output .= '- ' . wp_kses( sprintf( __( '<strong>Original string:</strong> %s', 'glotpress' ), $original->singular ), array( 'strong' => array() ) ) . '<br/>';
-		if ( array_key_exists( 'translation_id', $comment_meta ) && $comment_meta['translation_id'][0] ) {
-			$translation_id = $comment_meta['translation_id'][0];
-			$translation    = GP::$translation->get( $translation_id );
-			// todo: add the plurals.
-			if ( ! is_null( $translation ) ) {
-				/* translators: The translation string. */
-				$output .= '- ' . wp_kses( sprintf( __( '<strong>Translation string:</strong> %s', 'glotpress' ), $translation->translation_0 ), array( 'strong' => array() ) ) . '<br/>';
-			}
-		}
-		/* translators: The comment made. */
-		$output .= '- ' . wp_kses( sprintf( __( '<strong>Comment:</strong> %s', 'glotpress' ), $comment->comment_content ), array( 'strong' => array() ) );
 		$output .= '<br><br>';
 		$output .= esc_html__( 'Have a nice day!', 'glotpress' );
 		$output .= '<br><br>';
@@ -510,6 +546,19 @@ class GP_Notifications {
 		$project    = GP::$project->get( $project_id );
 
 		return $project;
+	}
+
+	/**
+	 * Adds a related comment (to the first one) when the validator makes a bulk rejection.
+	 *
+	 * @since 0.0.2
+	 *
+	 * @param WP_Comment $comment The related comment to add.
+	 *
+	 * @return void
+	 */
+	public static function add_related_comment( WP_Comment $comment ) {
+		self::$related_comments[] = $comment;
 	}
 
 	/**

--- a/includes/class-gp-translation-helpers.php
+++ b/includes/class-gp-translation-helpers.php
@@ -397,7 +397,7 @@ class GP_Translation_Helpers {
 		$first_translation_id = array_shift( $translation_id_array );
 
 		// Post comment on discussion page for the first string
-		$first_comment_id = $this->insert_reject_comment( $reject_comment, $post_id, $reject_reason, $first_translation_id, $locale_slug, $_SERVER );
+		$first_comment_id = $this->insert_reject_comment( $reject_comment, $first_original_id, $reject_reason, $first_translation_id, $locale_slug, $_SERVER );
 
 		if ( ! empty( $original_id_array ) && ! empty( $translation_id_array ) ) {
 			// For other strings post link to the comment.

--- a/includes/class-gp-translation-helpers.php
+++ b/includes/class-gp-translation-helpers.php
@@ -403,8 +403,10 @@ class GP_Translation_Helpers {
 			// For other strings post link to the comment.
 			$reject_comment = get_comment_link( $first_comment_id );
 			foreach ( $original_id_array as $index => $single_original_id ) {
-				$post_id = Helper_Translation_Discussion::get_shadow_post( $single_original_id );
-				$this->insert_reject_comment( $reject_comment, $post_id, $reject_reason, $translation_id_array[ $index ], $locale_slug, $_SERVER );
+				$post_id    = Helper_Translation_Discussion::get_shadow_post( $single_original_id );
+				$comment_id = $this->insert_reject_comment( $reject_comment, $post_id, $reject_reason, $translation_id_array[ $index ], $locale_slug, $_SERVER );
+				$comment    = get_comment( $comment_id );
+				GP_Notifications::add_related_comment( $comment );
 			}
 		}
 

--- a/includes/class-gp-translation-helpers.php
+++ b/includes/class-gp-translation-helpers.php
@@ -397,18 +397,23 @@ class GP_Translation_Helpers {
 		$post_id              = Helper_Translation_Discussion::get_shadow_post( $first_original_id );
 
 		// Post comment on discussion page for the first string
-		$save_feedback = $this->insert_reject_comment( $reject_comment, $post_id, $reject_reason, $first_translation_id, $locale_slug, $_SERVER );
+		$first_comment_id = $this->insert_reject_comment( $reject_comment, $post_id, $reject_reason, $first_translation_id, $locale_slug, $_SERVER );
 
 		if ( ! empty( $original_id_array ) && ! empty( $translation_id_array ) ) {
 			// For other strings post link to the comment.
-			$reject_comment = get_comment_link( $save_feedback );
+			$reject_comment = get_comment_link( $first_comment_id );
 			foreach ( $original_id_array as $index => $single_original_id ) {
 				$post_id = Helper_Translation_Discussion::get_shadow_post( $single_original_id );
 				$this->insert_reject_comment( $reject_comment, $post_id, $reject_reason, $translation_id_array[ $index ], $locale_slug, $_SERVER );
 			}
 		}
 
-		die();
+		if ( $first_comment_id ) {
+			$comment = get_comment( $first_comment_id );
+			GP_Notifications::init( $comment, null, null );
+		}
+
+		wp_send_json_success();
 	}
 
 	/**
@@ -475,8 +480,6 @@ class GP_Translation_Helpers {
 				),
 			)
 		);
-
-		wp_send_json_success();
 	}
 
 }

--- a/includes/class-gp-translation-helpers.php
+++ b/includes/class-gp-translation-helpers.php
@@ -403,8 +403,7 @@ class GP_Translation_Helpers {
 			// For other strings post link to the comment.
 			$reject_comment = get_comment_link( $first_comment_id );
 			foreach ( $original_id_array as $index => $single_original_id ) {
-				$post_id    = Helper_Translation_Discussion::get_shadow_post( $single_original_id );
-				$comment_id = $this->insert_reject_comment( $reject_comment, $post_id, $reject_reason, $translation_id_array[ $index ], $locale_slug, $_SERVER );
+				$comment_id = $this->insert_reject_comment( $reject_comment, $single_original_id, $reject_reason, $translation_id_array[ $index ], $locale_slug, $_SERVER );
 				$comment    = get_comment( $comment_id );
 				GP_Notifications::add_related_comment( $comment );
 			}


### PR DESCRIPTION
## Problem

When a validator rejects one or several strings, the plugin didn't send a notification to the translator.

## Solution

This PR sends a notification to the translator when one or several strings are rejected.

## Testing instructions

Add some translations with one user (user 1).

Reject one translation with a different user (user 2).

![image](https://user-images.githubusercontent.com/1667814/167368270-bddc0838-0325-4342-8328-80184ccfc9e2.png)

The translator (user 1) will get a notification.

![image](https://user-images.githubusercontent.com/1667814/167374023-4c1110fd-492e-4cf9-9994-03d3c4fa2f64.png)

Reject some translations in a bulk translation (user 2).

![image](https://user-images.githubusercontent.com/1667814/167368860-8a09aa73-23de-4753-bd3a-286c7b0c0968.png)

The translator (user 1) will get a notification with 2 URL, without the original and translation strings, because in this situation we have two or more strings.
 
![image](https://user-images.githubusercontent.com/1667814/167392451-c75096ae-198d-490f-b37b-025e410123e3.png)

