### PR TITLE
Fix typo causing PHP error

### DIFF
--- a/includes/class-wporg-notifications.php
+++ b/includes/class-wporg-notifications.php
@@ -192,7 +192,7 @@ class WPorg_GlotPress_Notifications {
 		}
 
 		if ( ( ! defined( 'WPORG_TRANSLATE_BLOGID' ) ) || ( false === $gp_locale ) ) {
-			return $array();
+			return array();
 		}
 
 		$project = self::get_project_to_translate( $comment );


### PR DESCRIPTION
#### Problem

There's a typo that caused this error  E_ERROR: Uncaught Error: Function name must be a string in /home/wporg/public_html/wp-content/plugins/gp-translation-helpers/includes/class-wporg-notifications.php:195

#### Solution

In this PR, I have removed the `$` sign causing the error


