### PR TITLE
Don't show popover  only if all selected strings are not untranslated

### DIFF
--- a/js/reject-feedback.js
+++ b/js/reject-feedback.js
@@ -43,7 +43,7 @@
 			$( '#bulk-actions-toolbar-top .button, #bulk-actions-toolbar .button' ).click( function( e ) {
 				rowIds = $( 'input:checked', $( 'table#translations th.checkbox' ) ).map( function() {
 					var selectedRow = $( this ).parents( 'tr.preview' );
-					if ( selectedRow.hasClass( 'status-current' ) ) {
+					if ( ! selectedRow.hasClass( 'untranslated' ) ) {
 						return selectedRow.attr( 'row' );
 					}
 					$( this ).prop( 'checked', false );


### PR DESCRIPTION
#### Problem
The popover for bulk reject is only shown if one or more strings selected is a current translation. If all strings selected are either waiting/fuzzy translations or does not contain at least one current translation, the popover doesn't display rather it throws an error "No translations were supplied".
**translate.wordpress.org**
![failed_bulk3](https://user-images.githubusercontent.com/2834132/172672663-4e6f7fb3-490b-4f82-8cdc-85322f84da93.gif)

**Local GlotPress install**
![failed_bulk4](https://user-images.githubusercontent.com/2834132/172676037-e6f556c6-971f-463c-b7db-d36b3a67fcad.gif)


#### Solution
Here's is how it's been fixed In this PR, when multiple strings are selected in a bulk selection each selected string is checked if it's not untranslated and then it's added to the array of selected strings.

#### Testing instructions
Choose any of these filter options and try to do a bulk reject
<img width="678" alt="image" src="https://user-images.githubusercontent.com/2834132/172674856-12607234-6e09-4307-bba8-b77f4003b26b.png">

The popover won't show up if the filter option is `untranslated` or if all the strings selected are untranslated.

