### PR TITLE
Add a new status: changes requested

### DIFF
--- a/gp-translation-helpers.php
+++ b/gp-translation-helpers.php
@@ -38,4 +38,4 @@ require_once __DIR__ . '/includes/class-wporg-notifications.php';
 add_action( 'gp_init', array( 'GP_Translation_Helpers', 'init' ) );
 add_action( 'gp_init', array( 'WPorg_GlotPress_Notifications', 'init' ) );    // todo: include this class in a different plugin.
 
-add_filter( 'gp_translation_helper_installed', '__return_true' ); // todo: remove this filter when this plugin will be merged in the GlotPress core.
+add_filter( 'gp_enable_changes_requested_status', '__return_true' ); // todo: remove this filter when this plugin will be merged in the GlotPress core.

--- a/gp-translation-helpers.php
+++ b/gp-translation-helpers.php
@@ -39,4 +39,4 @@ require_once __DIR__ . '/includes/class-wporg-customizations.php';
 add_action( 'gp_init', array( 'GP_Translation_Helpers', 'init' ) );
 add_action( 'gp_init', array( 'WPorg_GlotPress_Notifications', 'init' ) );    // todo: include this class in a different plugin.
 add_action( 'gp_init', array( 'WPorg_GlotPress_Customizations', 'init' ) );    // todo: include this class in a different plugin.
-add_filter( 'gp_enable_changes_requested_status', '__return_true' ); // todo: remove this filter when this plugin will be merged in the GlotPress core.
+add_filter( 'gp_enable_changesrequested_status', '__return_true' ); // todo: remove this filter when this plugin will be merged in the GlotPress core.

--- a/gp-translation-helpers.php
+++ b/gp-translation-helpers.php
@@ -37,3 +37,5 @@ require_once __DIR__ . '/includes/class-wporg-notifications.php';
 
 add_action( 'gp_init', array( 'GP_Translation_Helpers', 'init' ) );
 add_action( 'gp_init', array( 'WPorg_GlotPress_Notifications', 'init' ) );    // todo: include this class in a different plugin.
+
+add_filter( 'gp_translation_helper_installed', '__return_true' ); // todo: remove this filter when this plugin will be merged in the GlotPress core.

--- a/helpers/helper-translation-discussion.php
+++ b/helpers/helper-translation-discussion.php
@@ -859,7 +859,7 @@ function gth_discussion_callback( WP_Comment $comment, array $args, int $depth )
 
 			if ( $reject_reason ) :
 				?>
-				The translation <?php gth_print_translation( $comment_translation_id, $args ); ?> was rejected with <a href="<?php echo esc_url( $linked_comment ); ?>"><?php esc_html_e( 'a reason that is being discussed here' ); ?></a>.
+				The translation <?php gth_print_translation( $comment_translation_id, $args ); ?> was requested changes with <a href="<?php echo esc_url( $linked_comment ); ?>"><?php esc_html_e( 'a reason that is being discussed here' ); ?></a>.
 			<?php else : ?>
 				<a href="<?php echo esc_url( $linked_comment ); ?>"><?php esc_html_e( 'Please continue the discussion here' ); ?></a>
 			<?php endif; ?>
@@ -867,7 +867,7 @@ function gth_discussion_callback( WP_Comment $comment, array $args, int $depth )
 			<?php comment_text(); ?>
 			<?php if ( $reject_reason ) : ?>
 			<p>
-				<?php echo esc_html( _n( 'Rejection Reason: ', 'Rejection Reasons: ', count( $reject_reason ) ) ); ?>
+				<?php echo esc_html( _n( 'Requested Changes Reason: ', 'Requested Changes Reasons: ', count( $reject_reason ) ) ); ?>
 				<span><?php echo wp_kses( implode( '</span> | <span>', $reject_reason ), array( 'span' => array() ) ); ?></span>
 			</p>
 			<?php endif; ?>

--- a/includes/class-gp-notifications.php
+++ b/includes/class-gp-notifications.php
@@ -34,9 +34,6 @@ class GP_Notifications {
 				if ( ( '0' !== $comment->comment_parent ) ) { // Notify to the thread only if the comment is in a thread.
 					self::send_emails_to_thread_commenters( $comment, $comment_meta );
 				}
-				if ( ( '0' === $comment->comment_parent ) && array_key_exists( 'reject_reason', $comment_meta ) && ( ! empty( $comment_meta['reject_reason'] ) ) ) {  // Notify a rejection without parent comments.
-					self::send_rejection_email_to_translator( $comment, $comment_meta );
-				}
 				$root_comment      = self::get_root_comment_in_a_thread( $comment );
 				$root_comment_meta = get_comment_meta( $root_comment->comment_ID );
 				if ( array_key_exists( 'comment_topic', $root_comment_meta ) ) {
@@ -49,6 +46,8 @@ class GP_Notifications {
 							self::send_emails_to_validators( $comment, $comment_meta );
 							break;
 					}
+				} elseif ( ( '0' === $comment->comment_parent ) ) {  // Notify an approval, rejection or fuzzy without parent comments.
+					self::send_action_email_to_translator( $comment, $comment_meta );
 				}
 			}
 		}
@@ -103,7 +102,7 @@ class GP_Notifications {
 	}
 
 	/**
-	 * Sends the reject notification to the translator.
+	 * Sends the action notification (approval, rejection, fuzzy) to the translator.
 	 *
 	 * @since 0.0.2
 	 *
@@ -112,12 +111,12 @@ class GP_Notifications {
 	 *
 	 * @return void
 	 */
-	public static function send_rejection_email_to_translator( WP_Comment $comment, array $comment_meta ) {
+	public static function send_action_email_to_translator( WP_Comment $comment, array $comment_meta ) {
 		$translation_id = $comment_meta['translation_id'];
 		$translation    = GP::$translation->get( $translation_id );
-		$translator     = get_user_by( 'id', $translation->user_id_last_modified );
+		$translator     = get_user_by( 'id', $translation->user_id );
 		if ( false === $translator ) {
-			$translator = get_user_by( 'id', $translation->user_id );
+			$translator = get_user_by( 'id', $translation->user_id_last_modified );
 		}
 		self::send_emails( $comment, $comment_meta, array( $translator->user_email ) );
 	}

--- a/includes/class-gp-notifications.php
+++ b/includes/class-gp-notifications.php
@@ -118,7 +118,9 @@ class GP_Notifications {
 		if ( false === $translator ) {
 			$translator = get_user_by( 'id', $translation->user_id_last_modified );
 		}
-		self::send_emails( $comment, $comment_meta, array( $translator->user_email ) );
+		if ( false === $translator ) {
+			self::send_emails( $comment, $comment_meta, array( $translator->user_email ) );
+		}
 	}
 
 	/**

--- a/js/reject-feedback.js
+++ b/js/reject-feedback.js
@@ -205,8 +205,7 @@
 		);
 
 		comment = div.find( 'textarea[name="feedback_comment"]' ).val();
-
-		if ( ! comment.trim().length && ! commentReason.length ) {
+		if ( ( ( comment === undefined ) && ! commentReason.length ) || ( ( ! comment.trim().length && ! commentReason.length ) ) ) {
 			$gp.editor.set_status( button, status );
 			return;
 		}

--- a/js/reject-feedback.js
+++ b/js/reject-feedback.js
@@ -101,26 +101,40 @@
 				e.preventDefault();
 			} );
 
-			/**
-			 * Updates the 'Reject' button text in the Meta section when a validator
-			 * adds a comment in the 'Give feedback' area.
-			 *
-			 * If the textarea is empty, the value button text is "Reject". Otherwise,
-			 * is "Request changes"
-			 */
-			$( '.feedback-comment' ).on( 'input', function( e ) {
-				var form = $( this ).closest( 'form' );
-				var commentText = form.find( 'textarea[name="feedback_comment"]' ).val();
-				var div = $( this ).closest( '.meta' );
-				var button = $( '.reject', div );
-
-				if ( commentText.trim() !== '' ) {
-					button.html( '<strong>&minus;</strong> Request changes' );
-				} else {
-					button.html( '<strong>&minus;</strong> Reject' );
-				}
-				e.stopImmediatePropagation();
+			$( '.feedback-reason-list' ).on( 'click', function( e ) {
+				toggleButtons( $( this ), e );
 			} );
+			$( '.feedback-comment' ).on( 'input', function( e ) {
+				toggleButtons( $( this ), e );
+			} );
+
+			/**
+			 * Hide and show one of each two buttons: "Reject" and "Request changes".
+			 *
+			 * If the user has checked some reason or has entered some text in the textarea,
+			 * this function hides the "Reject" button and shows the "Request changes" one.
+			 * Otherwise, does the opposite.
+			 *
+			 * @param {Object}         thisObj The object that dispatches this call.
+			 * @param {document#event} event   The event.
+			 */
+			function toggleButtons( thisObj, event ) {
+				var form = thisObj.closest( 'form' );
+				var commentText = form.find( 'textarea[name="feedback_comment"]' ).val();
+				var div = thisObj.closest( '.meta' );
+				var rejectButton = $( '.reject', div );
+				var changesRequestedtButton = $( '.changes_requested', div );
+				var numberOfCheckedReasons = form.find( 'input[name="feedback_reason"]:checked' ).length;
+
+				if ( commentText.trim() !== '' || numberOfCheckedReasons ) {
+					rejectButton.hide();
+					changesRequestedtButton.show();
+				} else {
+					rejectButton.show();
+					changesRequestedtButton.hide();
+				}
+				event.stopImmediatePropagation();
+			}
 
 			/**
 			 * Updates the 'Reject' button text in the popup window (bulk rejection) when
@@ -199,7 +213,7 @@
 				if ( rejectData.is_bulk_reject ) {
 					$( 'form.filters-toolbar.bulk-actions, form#bulk-actions-toolbar-top' ).submit();
 				} else {
-					$gp.editor.set_status( button, 'rejected' );
+					$gp.editor.set_status( button, 'changes_requested' );
 					div.find( 'input[name="feedback_reason"]' ).prop( 'checked', false );
 					div.find( 'textarea[name="feedback_comment"]' ).val( '' );
 				}

--- a/js/reject-feedback.js
+++ b/js/reject-feedback.js
@@ -100,6 +100,14 @@
 				rejectWithFeedback( rejectData );
 				e.preventDefault();
 			} );
+
+			/**
+			 * Updates the 'Reject' button text in the Meta section when a validator
+			 * adds a comment in the 'Give feedback' area.
+			 *
+			 * If the textarea is empty, the value button text is "Reject". Otherwise,
+			 * is "Request changes"
+			 */
 			$( '.feedback-comment' ).on( 'input', function( e ) {
 				var form = $( this ).closest( 'form' );
 				var commentText = form.find( 'textarea[name="feedback_comment"]' ).val();
@@ -111,7 +119,26 @@
 				} else {
 					button.html( '<strong>&minus;</strong> Reject' );
 				}
-				e.preventDefault();
+				e.stopImmediatePropagation();
+			} );
+
+			/**
+			 * Updates the 'Reject' button text in the popup window (bulk rejection) when
+			 * a validator adds a comment in the textarea.
+			 *
+			 * If the textarea is empty, the value button text is "Reject". Otherwise,
+			 * is "Request changes"
+			 */
+			$( 'textarea[name="modal_feedback_comment"]' ).on( 'input', function( e ) {
+				var commentText = $( this ).val();
+				var div = $( this ).closest( '#TB_ajaxContent' );
+				var button = $( '#modal-reject-btn', div );
+
+				if ( commentText.trim() !== '' ) {
+					button.html( 'Request changes' );
+				} else {
+					button.html( 'Reject' );
+				}
 				e.stopImmediatePropagation();
 			} );
 		}

--- a/js/reject-feedback.js
+++ b/js/reject-feedback.js
@@ -15,7 +15,7 @@
 					'<textarea name="modal_feedback_comment"></textarea>' +
 			'</div>' +
 			'<button id="modal-reject-btn" class="modal-btn gp-btn-style">Reject</button>' +
-			'<button id="modal-request_changes-btn"  style="display: none;" class="modal-btn">Request changes</button>' +
+			'<button id="modal-request_changes-btn" class="modal-btn gp-btn-style" style="display: none;" class="modal-btn">Request changes</button>' +
 			'</form>' +
 			'</div>';
 
@@ -271,7 +271,7 @@
 
 		// eslint-disable-next-line vars-on-top
 		for ( var reason in commentReasons ) {
-			prefix = '<div class="modal-item">><label class="tooltip" title="' + commentReasons[ reason ].explanation + '">';
+			prefix = '<div class="modal-item"><label class="tooltip" title="' + commentReasons[ reason ].explanation + '">';
 			suffix = '</label> <span class="tooltip dashicons dashicons-info" title="' + commentReasons[ reason ].explanation + '"></span></div>';
 			inputName = 'modal_feedback_reason';
 			commentList += prefix + '<input type="checkbox" name="' + inputName + '" value="' + reason + '" /> ' + commentReasons[ reason ].name + suffix;

--- a/js/reject-feedback.js
+++ b/js/reject-feedback.js
@@ -15,7 +15,7 @@
 					'<textarea name="modal_feedback_comment"></textarea>' +
 			'</div>' +
 			'<button id="modal-reject-btn" class="modal-btn gp-btn-style">Reject</button>' +
-			'<button id="modal-request_changes-btn" class="modal-btn gp-btn-style" style="display: none;" class="modal-btn">Request changes</button>' +
+			'<button id="modal-requestchanges-btn" class="modal-btn gp-btn-style" style="display: none;" class="modal-btn">Request changes</button>' +
 			'</form>' +
 			'</div>';
 
@@ -67,11 +67,11 @@
 				var commentText = form.find( 'textarea[name="modal_feedback_comment"]' ).val();
 				var numberOfCheckedReasons = form.find( 'input[name="modal_feedback_reason"]:checked' ).length;
 				if ( commentText || numberOfCheckedReasons ) {
-					$( 'form#bulk-actions-toolbar-top  option[value="reject"]' ).attr( 'value', 'changes_requested' ).text( 'Changes requested' );
+					$( 'form#bulk-actions-toolbar-top  option[value="reject"]' ).attr( 'value', 'changesrequested' ).text( 'Changes requested' );
 				}
 			}
 
-			$( 'body' ).on( 'click', '#modal-reject-btn, #modal-request_changes-btn', function( e ) {
+			$( 'body' ).on( 'click', '#modal-reject-btn, #modal-requestchanges-btn', function( e ) {
 				var comment = '';
 				var commentReason = [];
 				var commentData = {};
@@ -121,7 +121,7 @@
 				var commentText = form.find( 'textarea[name="feedback_comment"]' ).val();
 				var div = thisObj.closest( '.meta' );
 				var rejectButton = $( '.reject', div );
-				var changesRequestedtButton = $( '.changes_requested', div );
+				var changesRequestedtButton = $( '.changesrequested', div );
 				var numberOfCheckedReasons = form.find( 'input[name="feedback_reason"]:checked' ).length;
 
 				if ( commentText.trim() !== '' || numberOfCheckedReasons ) {
@@ -156,7 +156,7 @@
 				var commentText = form.find( 'textarea[name="modal_feedback_comment"]' ).val();
 				var div = thisObj.closest( '#TB_ajaxContent' );
 				var rejectButton = $( '#modal-reject-btn', div );
-				var changesRequestedtButton = $( '#modal-request_changes-btn', div );
+				var changesRequestedtButton = $( '#modal-requestchanges-btn', div );
 				var numberOfCheckedReasons = form.find( 'input[name="modal_feedback_reason"]:checked' ).length;
 
 				if ( commentText.trim() !== '' || numberOfCheckedReasons ) {
@@ -187,8 +187,8 @@
 		setStatus( $( this ), 'rejected' );
 	};
 
-	$gp.editor.hooks.set_status_changes_requested = function() {
-		setStatus( $( this ), 'changes_requested' );
+	$gp.editor.hooks.set_status_changesrequested = function() {
+		setStatus( $( this ), 'changesrequested' );
 	};
 
 	function setStatus( that, status ) {

--- a/js/reject-feedback.js
+++ b/js/reject-feedback.js
@@ -14,7 +14,7 @@
 			'</ul>' +
 			'<div class="feedback-comment">' +
 				'<label>Comment </label>' +
-				'<textarea name="feedback_comment"></textarea>' +
+				'<textarea name="feedback_comment" class="feedback-comment"></textarea>' +
 			'</div>' +
 			'</form>' +
 			'</div>' +
@@ -99,6 +99,20 @@
 				rejectData.is_bulk_reject = true;
 				rejectWithFeedback( rejectData );
 				e.preventDefault();
+			} );
+			$( '.feedback-comment' ).on( 'input', function( e ) {
+				var form = $( this ).closest( 'form' );
+				var commentText = form.find( 'textarea[name="feedback_comment"]' ).val();
+				var div = $( this ).closest( '.meta' );
+				var button = $( '.reject', div );
+
+				if ( commentText.trim() !== '' ) {
+					button.html( '<strong>&minus;</strong> Request changes' );
+				} else {
+					button.html( '<strong>&minus;</strong> Reject' );
+				}
+				e.preventDefault();
+				e.stopImmediatePropagation();
 			} );
 		}
 	);

--- a/js/reject-feedback.js
+++ b/js/reject-feedback.js
@@ -25,7 +25,6 @@
 			$( $gp.editor.table ).off( 'click', 'summary' );
 
 			$( '#bulk-actions-toolbar-top .button, #bulk-actions-toolbar-bottom .button' ).click( function( e ) {
-
 				rowIds = $( 'input:checked', $( 'table#translations th.checkbox' ) ).map( function() {
 					var selectedRow = $( this ).parents( 'tr.preview' );
 					if ( ! selectedRow.hasClass( 'untranslated' ) ) {
@@ -86,7 +85,7 @@
 
 				comment = form.find( 'textarea[name="modal_feedback_comment"]' ).val();
 				updateBulkRejectStatus( $( this ) );
-			if ( ( ! comment.trim().length && ! commentReason.length ) || ( ! translationIds.length || ! originalIds.length ) ) {
+				if ( ( ! comment.trim().length && ! commentReason.length ) || ( ! translationIds.length || ! originalIds.length ) ) {
 					$( 'form.filters-toolbar.bulk-actions, form#bulk-actions-toolbar-top' ).submit();
 				}
 
@@ -244,7 +243,7 @@
 			}
 		).done(
 			function() {
- 				if ( feedbackData.is_bulk_reject ) {
+				if ( feedbackData.is_bulk_reject ) {
 					$( 'form.filters-toolbar.bulk-actions, form#bulk-actions-toolbar-top' ).submit();
 				} else {
 					$gp.editor.set_status( button, status );

--- a/templates/gp-templates-overrides/translation-row-editor-meta-status.php
+++ b/templates/gp-templates-overrides/translation-row-editor-meta-status.php
@@ -19,7 +19,7 @@
 				<?php endif; ?>
 				<?php if ( 'rejected' !== $translation->translation_status ) : ?>
 					<button class="reject" data-nonce="<?php echo esc_attr( wp_create_nonce( 'update-translation-status-rejected_' . $translation->id ) ); ?>" title="<?php esc_attr_e( 'Reject this translation. The existing translation will be kept as part of the translation history.', 'glotpress' ); ?>"><strong>&minus;</strong> <?php _ex( 'Reject', 'Action', 'glotpress' ); ?></button>
-					<button class="     changes_requested" style="display: none;" data-nonce="<?php echo esc_attr( wp_create_nonce( 'update-translation-status-changes_requested_' . $translation->id ) ); ?>" title="<?php esc_attr_e( 'Request changes for this translation. The existing translation will be kept as part of the translation history.', 'glotpress' ); ?>"><strong>&minus;</strong> <?php _ex( 'Request changes', 'Action', 'glotpress' ); ?></button>
+					<button class="changesrequested" style="display: none;" data-nonce="<?php echo esc_attr( wp_create_nonce( 'update-translation-status-changesrequested_' . $translation->id ) ); ?>" title="<?php esc_attr_e( 'Request changes for this translation. The existing translation will be kept as part of the translation history.', 'glotpress' ); ?>"><strong>&minus;</strong> <?php _ex( 'Request changes', 'Action', 'glotpress' ); ?></button>
 				<?php endif; ?>
 				<?php if ( 'fuzzy' !== $translation->translation_status ) : ?>
 					<button class="fuzzy" data-nonce="<?php echo esc_attr( wp_create_nonce( 'update-translation-status-fuzzy_' . $translation->id ) ); ?>" title="<?php esc_attr_e( 'Mark this translation as fuzzy for further review.', 'glotpress' ); ?>"><strong>~</strong> <?php _ex( 'Fuzzy', 'Action', 'glotpress' ); ?></button>

--- a/templates/gp-templates-overrides/translation-row-editor-meta-status.php
+++ b/templates/gp-templates-overrides/translation-row-editor-meta-status.php
@@ -19,6 +19,7 @@
 				<?php endif; ?>
 				<?php if ( 'rejected' !== $translation->translation_status ) : ?>
 					<button class="reject" data-nonce="<?php echo esc_attr( wp_create_nonce( 'update-translation-status-rejected_' . $translation->id ) ); ?>" title="<?php esc_attr_e( 'Reject this translation. The existing translation will be kept as part of the translation history.', 'glotpress' ); ?>"><strong>&minus;</strong> <?php _ex( 'Reject', 'Action', 'glotpress' ); ?></button>
+					<button class="     changes_requested" style="display: none;" data-nonce="<?php echo esc_attr( wp_create_nonce( 'update-translation-status-changes_requested_' . $translation->id ) ); ?>" title="<?php esc_attr_e( 'Request changes for this translation. The existing translation will be kept as part of the translation history.', 'glotpress' ); ?>"><strong>&minus;</strong> <?php _ex( 'Request changes', 'Action', 'glotpress' ); ?></button>
 				<?php endif; ?>
 				<?php if ( 'fuzzy' !== $translation->translation_status ) : ?>
 					<button class="fuzzy" data-nonce="<?php echo esc_attr( wp_create_nonce( 'update-translation-status-fuzzy_' . $translation->id ) ); ?>" title="<?php esc_attr_e( 'Mark this translation as fuzzy for further review.', 'glotpress' ); ?>"><strong>~</strong> <?php _ex( 'Fuzzy', 'Action', 'glotpress' ); ?></button>


### PR DESCRIPTION
## Problem

<!--
Please describe what is the status/problem before the PR.
-->

This PR, with [another one](https://github.com/GlotPress/GlotPress/pull/1451) in the GlotPress plugin, adds a new status: changes requested.

## Solution

<!--
Please describe how this PR improves the situation.
-->

This plugin only send the information with a new status (changes_requested) when:
- A simple rejection is made, adding some feedback.
- A bulk rejection is made, adding some feedback.

## Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

To test this PR, you have to use the [related branch](https://github.com/GlotPress/GlotPress/pull/1451) from GlotPress and you have to reject some strings as validator (simple or bulk rejection), adding some feedback.