### PR TITLE
Add '(required)' to comment required form labels

### DIFF
--- a/helpers-assets/templates/translation-discussion-comments.php
+++ b/helpers-assets/templates/translation-discussion-comments.php
@@ -72,7 +72,7 @@
 			}
 
 			echo '<p class="comment-form-topic">
-					<label for="comment_topic">Topic <span class="required" aria-hidden="true">*</span></label>
+					<label for="comment_topic">Topic <span class="required" aria-hidden="true">*</span> (required)</label>
 					<select required name="comment_topic" id="comment_topic">
 						<option value="">Select topic</option>
 						<option value="typo">Typo in the English text</option>

--- a/helpers/helper-translation-discussion.php
+++ b/helpers/helper-translation-discussion.php
@@ -510,7 +510,7 @@ class Helper_Translation_Discussion extends GP_Translation_Helper {
 		add_filter(
 			'comment_form_fields',
 			function( $comment_fields ) {
-				$comment_fields['comment'] = str_replace( '>Comment<', '>Please leave your comment about this string here:<', $comment_fields['comment'] );
+				$comment_fields['comment'] = str_replace( '</label>', ' (required)</label>', $comment_fields['comment'] );
 				return $comment_fields;
 			}
 		);
@@ -928,6 +928,7 @@ function gth_discussion_callback( WP_Comment $comment, array $args, int $depth )
 							'title_reply_to'      => esc_html__( 'Reply to %s' ),
 							'title_reply_before'  => '<h5 id="reply-title" class="discuss-title">',
 							'title_reply_after'   => '</h5>',
+							'comment_field'       => '<p class="">',
 							'id_form'             => 'commentform-' . $comment->comment_post_ID,
 							'cancel_reply_link'   => '<span></span>',
 							'comment_notes_after' => implode(


### PR DESCRIPTION

#### Problem

Some users can't correctly tell what `*` means. Hence, we need to add a short note (e.g 'Required') beside the `*` explaining what we mean by adding `*` to the form labels.
![177989177-ca96b40a-64c5-40b8-84e8-064537811594](https://user-images.githubusercontent.com/2834132/177989663-2bd86e15-6168-46a0-bf5d-39fd36908a70.png)

#### Solution

In this PR I have added a text 'required' to the labels of required fields. Here's how it now looks, see below;

![Screenshot 2022-07-14 at 17 43 54](https://user-images.githubusercontent.com/2834132/179034818-89511739-1ae7-4076-936a-ef7fbf3b0202.png)

