### PR TITLE
GP: Increase the line-height in the original string, in the discussion

### DIFF
--- a/css/discussion.css
+++ b/css/discussion.css
@@ -4,7 +4,7 @@
 
 #original h1 {
 	margin: .5em 14px;
-	line-height: 34px;
+	line-height: 45px;
 }
 
 #original p {


### PR DESCRIPTION
## Problem

This PR improves the header section for long originals, because the texts overlap (or  are very near) in the lines in the original string.

![image](https://user-images.githubusercontent.com/1667814/179474535-394c44ba-fd2a-4400-834c-5a9981f5d413.png)

<!--
Please describe what is the status/problem before the PR.
-->

## Solution

The solution was increasing the line-height. The current font-size is 32px (at GlotPress and at translate.w.org) and the line-height is 34px. I have increased the line-height to 45 px (32*1,4).

<!--
Please describe how this PR improves the situation.
-->

## Testing instructions

You need to test it manually. 

### GlotPress

#### Before 
![image](https://user-images.githubusercontent.com/1667814/179468507-7cfd6f09-29cd-44ba-84b4-25d8d5e73094.png)

#### After
![image](https://user-images.githubusercontent.com/1667814/179470151-4530933b-1883-4478-9ed2-f4165564ec62.png)

###  translate.w.org

https://translate.wordpress.org/projects/wp/dev/13717071/gl/default/ 

#### Before 
![image](https://user-images.githubusercontent.com/1667814/179473291-25796238-d3b9-4e88-b0c2-56960c88f5cc.png)

#### After
![image](https://user-images.githubusercontent.com/1667814/179473933-24dfe42c-87cb-401b-94b9-aa4432934873.png)
<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

