### PR TITLE
Update the values showed as reject reason

### DIFF
--- a/helpers/helper-translation-discussion.php
+++ b/helpers/helper-translation-discussion.php
@@ -806,6 +806,10 @@ function gth_discussion_callback( WP_Comment $comment, array $args, int $depth )
 	$comment_translation_id = get_comment_meta( $comment->comment_ID, 'translation_id', true );
 
 	$reject_reason = get_comment_meta( $comment->comment_ID, 'reject_reason', true );
+	$reject_reason = array_map(
+		fn ( $reason) => Helper_Translation_Discussion::get_reject_reasons()[ $reason ],
+		$reject_reason
+	);
 
 	$classes = array( 'comment-locale-' . $comment_locale );
 	if ( ! empty( $reject_reason ) ) {


### PR DESCRIPTION
## Problem

When we reject a translation with some reason, we are using the [keys from this array ](https://github.com/GlotPress/gp-translation-helpers/blob/e1809688cf960c90dcf9169764d15f47f871f166/helpers/helper-translation-discussion.php#L727)when we show the text:
 
![image](https://user-images.githubusercontent.com/1667814/179494007-ee56b4eb-144d-4fd4-98f4-8ff30fc2f5b2.png)

<!--
Please describe what is the status/problem before the PR.
-->

## Solution

This PR change this behavior to show the values:

![image](https://user-images.githubusercontent.com/1667814/179494618-7f1f44a9-e8ac-416d-8939-aff85c327d29.png)

<!--
Please describe how this PR improves the situation.
-->

## Testing instructions

You need to test it manually:
* Reject some translations with some reasons. 
* Then you have to go to the discussion page to see the correct text.

![image](https://user-images.githubusercontent.com/1667814/179495777-1485a4a7-026d-4104-ac3d-720cfb14ffaa.png)



<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

