### PR TITLE
Add the tooltips to the reject reasons

### DIFF
--- a/css/discussion.css
+++ b/css/discussion.css
@@ -71,6 +71,11 @@ article.comment time {
 .feedback-reason-list span.dashicons.dashicons-info,
 #TB_window span.dashicons.dashicons-info {
 	color: #D3D3D3;
+	font-size:16px;
+}
+.feedback-reason-list li {
+	white-space:nowrap;
+	padding-right: 2px;
 }
 .ui-tooltip {
 	z-index: 100051 !important;

--- a/css/discussion.css
+++ b/css/discussion.css
@@ -217,3 +217,7 @@ div#TB_ajaxWindowTitle {
 	-webkit-box-shadow: none;
 	box-shadow: none;
 }
+
+.hoverTooltip {
+	position: fixed !important;
+}

--- a/css/discussion.css
+++ b/css/discussion.css
@@ -73,7 +73,7 @@ article.comment time {
 	color: #D3D3D3;
 }
 .ui-tooltip {
-	z-index: 100051;
+	z-index: 100051 !important;
 }
 .comment-form-comment label{
 	display: block;

--- a/css/discussion.css
+++ b/css/discussion.css
@@ -67,6 +67,14 @@ article.comment time {
 .comment-content {
 	text-align: start;
 }
+.comment-content span.dashicons.dashicons-info,
+.feedback-reason-list span.dashicons.dashicons-info,
+#TB_window span.dashicons.dashicons-info {
+	color: #D3D3D3;
+}
+.ui-tooltip {
+	z-index: 100051;
+}
 .comment-form-comment label{
 	display: block;
 }

--- a/helpers/helper-translation-discussion.php
+++ b/helpers/helper-translation-discussion.php
@@ -744,8 +744,8 @@ class Helper_Translation_Discussion extends GP_Translation_Helper {
 	 */
 	public static function get_reject_reason_explanations(): array {
 		return array(
-			'style'       => __( 'The translation is not following the style guide. It will be interesting to provide a link to the style guide for you locale in the comment.' ),
-			'grammar'     => __( 'The translation has some grammar problems. It will be interesting to provide a link explaining the grammar issue for you locale in the comment.' ),
+			'style'       => __( 'The translation is not following the style guide. It will be interesting to provide a link to the style guide for your locale in the comment.' ),
+			'grammar'     => __( 'The translation has some grammar problems. It will be interesting to provide a link explaining the grammar issue for your locale in the comment.' ),
 			'branding'    => __( 'The translation is using incorrectly some brand. E.g. WordPress without the capital P.' ),
 			'glossary'    => __( 'The translation is not using the glossary correctly. It will be interesting to provide some link to the glossary for your locale in the comment.' ),
 			'punctuation' => __( 'The translation is not using the punctuation marks correctly.' ),

--- a/helpers/helper-translation-discussion.php
+++ b/helpers/helper-translation-discussion.php
@@ -889,13 +889,14 @@ function gth_discussion_callback( WP_Comment $comment, array $args, int $depth )
 				<?php
 				$number_of_items = count( $reject_reason );
 				$counter         = 0;
+				$reject_reasons  = Helper_Translation_Discussion::get_reject_reasons();
 				foreach ( $reject_reason as $reason ) {
 					echo wp_kses(
 						sprintf(
 						/* translators: 1: Title with the explanation of the reject reason , 2: The reject reason */
 							__( '<span title="%1$s" class="tooltip">%2$s</span> <span class="tooltip dashicons dashicons-info" title="%1$s"></span>', 'glotpress' ),
-							Helper_Translation_Discussion::get_reject_reasons()[ $reason ]['explanation'],
-							$reason
+							$reject_reasons[ $reason ]['explanation'],
+							$reject_reasons[ $reason ]['name'],
 						),
 						array(
 							'span' => array(

--- a/helpers/helper-translation-discussion.php
+++ b/helpers/helper-translation-discussion.php
@@ -886,7 +886,16 @@ function gth_discussion_callback( WP_Comment $comment, array $args, int $depth )
 			<?php if ( $reject_reason ) : ?>
 			<p>
 				<?php echo esc_html( _n( 'Rejection Reason: ', 'Rejection Reasons: ', count( $reject_reason ) ) ); ?>
-				<span><?php echo wp_kses( implode( '</span> | <span>', $reject_reason ), array( 'span' => array() ) ); ?></span>
+				<?php
+				$number_of_items = count( $reject_reason );
+				$counter         = 0;
+				foreach ( $reject_reason as $reason ) {
+					echo '<span title="' . Helper_Translation_Discussion::get_reject_reason_explanations()[ $reason ] . '">' . $reason . '</span>';
+					if ( ++$counter < $number_of_items ) {
+						echo ' | ';
+					}
+				}
+				?>
 			</p>
 			<?php endif; ?>
 		<?php endif; ?>

--- a/helpers/helper-translation-discussion.php
+++ b/helpers/helper-translation-discussion.php
@@ -890,7 +890,16 @@ function gth_discussion_callback( WP_Comment $comment, array $args, int $depth )
 				$number_of_items = count( $reject_reason );
 				$counter         = 0;
 				foreach ( $reject_reason as $reason ) {
-					echo '<span title="' . Helper_Translation_Discussion::get_reject_reason_explanations()[ $reason ] . '">' . $reason . '</span>';
+					echo wp_kses(
+						sprintf(
+						/* translators: 1: Title with the explanation of the reject reason , 2: The reject reason */
+							__( '<span title="%1$s">%2$s</span>', 'glotpress' ),
+							Helper_Translation_Discussion::get_reject_reason_explanations()[ $reason ],
+							$reason
+						),
+						array( 'span' => array( 'title' => array() ) )
+					);
+
 					if ( ++$counter < $number_of_items ) {
 						echo ' | ';
 					}

--- a/helpers/helper-translation-discussion.php
+++ b/helpers/helper-translation-discussion.php
@@ -893,15 +893,20 @@ function gth_discussion_callback( WP_Comment $comment, array $args, int $depth )
 					echo wp_kses(
 						sprintf(
 						/* translators: 1: Title with the explanation of the reject reason , 2: The reject reason */
-							__( '<span title="%1$s">%2$s</span>', 'glotpress' ),
+							__( '<span title="%1$s" class="tooltip">%2$s</span> <span class="tooltip dashicons dashicons-info" title="%1$s"></span>', 'glotpress' ),
 							Helper_Translation_Discussion::get_reject_reason_explanations()[ $reason ],
 							$reason
 						),
-						array( 'span' => array( 'title' => array() ) )
+						array(
+							'span' => array(
+								'class' => array(),
+								'title' => array(),
+							),
+						)
 					);
 
 					if ( ++$counter < $number_of_items ) {
-						echo ' | ';
+						echo ', ';
 					}
 				}
 				?>

--- a/helpers/helper-translation-discussion.php
+++ b/helpers/helper-translation-discussion.php
@@ -718,7 +718,7 @@ class Helper_Translation_Discussion extends GP_Translation_Helper {
 	}
 
 	/**
-	 * Return an array of allowed rejection reasons
+	 * Return an array of allowed rejection reasons and explanation of each reason.
 	 *
 	 * @since 0.0.2
 	 *
@@ -726,33 +726,33 @@ class Helper_Translation_Discussion extends GP_Translation_Helper {
 	 */
 	public static function get_reject_reasons(): array {
 		return array(
-			'style'       => __( 'Style Guide' ),
-			'grammar'     => __( 'Grammar' ),
-			'branding'    => __( 'Branding' ),
-			'glossary'    => __( 'Glossary' ),
-			'punctuation' => __( 'Punctuation' ),
-			'typo'        => __( 'Typo' ),
+			'style'       => array(
+				'name'        => __( 'Style Guide' ),
+				'explanation' => __( 'The translation is not following the style guide. It will be interesting to provide a link to the style guide for your locale in the comment.' ),
+			),
+			'grammar'     => array(
+				'name'        => __( 'Grammar' ),
+				'explanation' => __( 'The translation has some grammar problems. It will be interesting to provide a link explaining the grammar issue for your locale in the comment.' ),
+			),
+			'branding'    => array(
+				'name'        => __( 'Branding' ),
+				'explanation' => __( 'The translation is using incorrectly some brand. E.g. WordPress without the capital P.' ),
+			),
+			'glossary'    => array(
+				'name'        => __( 'Glossary' ),
+				'explanation' => __( 'The translation is not using the glossary correctly. It will be interesting to provide some link to the glossary for your locale in the comment.' ),
+			),
+			'punctuation' => array(
+				'name'        => __( 'Punctuation' ),
+				'explanation' =>
+					__( 'The translation is not using the punctuation marks correctly.' ),
+			),
+			'typo'        => array(
+				'name'        => __( 'Typo' ),
+				'explanation' => __( 'The translation has a typo. E.g., it is using the \'apostrope\' word instead of \'apostrophe\'.' ),
+			),
 		);
 	}
-
-	/**
-	 * Return an array with the explanations for the allowed rejection reasons
-	 *
-	 * @since 0.0.2
-	 *
-	 * @return array
-	 */
-	public static function get_reject_reason_explanations(): array {
-		return array(
-			'style'       => __( 'The translation is not following the style guide. It will be interesting to provide a link to the style guide for your locale in the comment.' ),
-			'grammar'     => __( 'The translation has some grammar problems. It will be interesting to provide a link explaining the grammar issue for your locale in the comment.' ),
-			'branding'    => __( 'The translation is using incorrectly some brand. E.g. WordPress without the capital P.' ),
-			'glossary'    => __( 'The translation is not using the glossary correctly. It will be interesting to provide some link to the glossary for your locale in the comment.' ),
-			'punctuation' => __( 'The translation is not using the punctuation marks correctly.' ),
-			'typo'        => __( 'The translation has a typo. E.g., it is using the \'apostrope\' word instead of \'apostrophe\'.' ),
-		);
-	}
-
 }
 
 /**
@@ -894,7 +894,7 @@ function gth_discussion_callback( WP_Comment $comment, array $args, int $depth )
 						sprintf(
 						/* translators: 1: Title with the explanation of the reject reason , 2: The reject reason */
 							__( '<span title="%1$s" class="tooltip">%2$s</span> <span class="tooltip dashicons dashicons-info" title="%1$s"></span>', 'glotpress' ),
-							Helper_Translation_Discussion::get_reject_reason_explanations()[ $reason ],
+							Helper_Translation_Discussion::get_reject_reasons()[ $reason ]['explanation'],
 							$reason
 						),
 						array(

--- a/helpers/helper-translation-discussion.php
+++ b/helpers/helper-translation-discussion.php
@@ -724,7 +724,7 @@ class Helper_Translation_Discussion extends GP_Translation_Helper {
 	 *
 	 * @return array
 	 */
-	public static function get_reject_reasons() {
+	public static function get_reject_reasons(): array {
 		return array(
 			'style'       => __( 'Style Guide' ),
 			'grammar'     => __( 'Grammar' ),
@@ -732,6 +732,24 @@ class Helper_Translation_Discussion extends GP_Translation_Helper {
 			'glossary'    => __( 'Glossary' ),
 			'punctuation' => __( 'Punctuation' ),
 			'typo'        => __( 'Typo' ),
+		);
+	}
+
+	/**
+	 * Return an array with the explanations for the allowed rejection reasons
+	 *
+	 * @since 0.0.2
+	 *
+	 * @return array
+	 */
+	public static function get_reject_reason_explanations(): array {
+		return array(
+			'style'       => __( 'The translation is not following the style guide. It will be interesting to provide a link to the style guide for you locale in the comment.' ),
+			'grammar'     => __( 'The translation has some grammar problems. It will be interesting to provide a link explaining the grammar issue for you locale in the comment.' ),
+			'branding'    => __( 'The translation is using incorrectly some brand. E.g. WordPress without the capital P.' ),
+			'glossary'    => __( 'The translation is not using the glossary correctly. It will be interesting to provide some link to the glossary for your locale in the comment.' ),
+			'punctuation' => __( 'The translation is not using the punctuation marks correctly.' ),
+			'typo'        => __( 'The translation has a typo. E.g., it is using the \'apostrope\' word instead of \'apostrophe\'.' ),
 		);
 	}
 

--- a/includes/class-gp-translation-helpers.php
+++ b/includes/class-gp-translation-helpers.php
@@ -370,11 +370,10 @@ class GP_Translation_Helpers {
 			'gp-reject-feedback-js',
 			'$gp_reject_feedback_settings',
 			array(
-				'url'                        => admin_url( 'admin-ajax.php' ),
-				'nonce'                      => wp_create_nonce( 'gp_reject_feedback' ),
-				'locale_slug'                => $translation_set['locale_slug'],
-				'reject_reasons'             => Helper_Translation_Discussion::get_reject_reasons(),
-				'reject_reason_explanations' => Helper_Translation_Discussion::get_reject_reason_explanations(),
+				'url'            => admin_url( 'admin-ajax.php' ),
+				'nonce'          => wp_create_nonce( 'gp_reject_feedback' ),
+				'locale_slug'    => $translation_set['locale_slug'],
+				'reject_reasons' => Helper_Translation_Discussion::get_reject_reasons(),
 			)
 		);
 	}

--- a/includes/class-gp-translation-helpers.php
+++ b/includes/class-gp-translation-helpers.php
@@ -356,10 +356,11 @@ class GP_Translation_Helpers {
 			'gp-reject-feedback-js',
 			'$gp_reject_feedback_settings',
 			array(
-				'url'            => admin_url( 'admin-ajax.php' ),
-				'nonce'          => wp_create_nonce( 'gp_reject_feedback' ),
-				'locale_slug'    => $translation_set['locale_slug'],
-				'reject_reasons' => Helper_Translation_Discussion::get_reject_reasons(),
+				'url'                        => admin_url( 'admin-ajax.php' ),
+				'nonce'                      => wp_create_nonce( 'gp_reject_feedback' ),
+				'locale_slug'                => $translation_set['locale_slug'],
+				'reject_reasons'             => Helper_Translation_Discussion::get_reject_reasons(),
+				'reject_reason_explanations' => Helper_Translation_Discussion::get_reject_reason_explanations(),
 			)
 		);
 	}

--- a/js/reject-feedback.js
+++ b/js/reject-feedback.js
@@ -153,7 +153,6 @@
 
 	function getReasonList( displayType ) {
 		var rejectReasons = $gp_reject_feedback_settings.reject_reasons;
-		var rejectReasonExplanations = $gp_reject_feedback_settings.reject_reason_explanations;
 		var rejectList = '';
 		var prefix = '';
 		var suffix = '';
@@ -162,15 +161,15 @@
 		// eslint-disable-next-line vars-on-top
 		for ( var reason in rejectReasons ) {
 			if ( displayType === 'single' ) {
-				prefix = '<li><label class="tooltip" title="' + rejectReasonExplanations[ reason ] + '">';
-				suffix = '</label> <span class="tooltip dashicons dashicons-info" title="' + rejectReasonExplanations[ reason ] + '"></span></li>';
+				prefix = '<li><label class="tooltip" title="' + rejectReasons[ reason ].explanation + '">';
+				suffix = '</label> <span class="tooltip dashicons dashicons-info" title="' + rejectReasons[ reason ].explanation + '"></span></li>';
 				inputName = 'feedback_reason';
 			} else {
-				prefix = '<div class="modal-item"><label class="tooltip" title="' + rejectReasonExplanations[ reason ] + '">';
-				suffix = '</label> <span class="tooltip dashicons dashicons-info" title="' + rejectReasonExplanations[ reason ] + '"></span></div>';
+				prefix = '<div class="modal-item"><label class="tooltip" title="' + rejectReasons[ reason ].explanation + '">';
+				suffix = '</label> <span class="tooltip dashicons dashicons-info" title="' + rejectReasons[ reason ].explanation + '"></span></div>';
 				inputName = 'modal_feedback_reason';
 			}
-			rejectList += prefix + '<input type="checkbox" name="' + inputName + '" value="' + reason + '" />' + rejectReasons[ reason ] + suffix;
+			rejectList += prefix + '<input type="checkbox" name="' + inputName + '" value="' + reason + '" />' + rejectReasons[ reason ].name + suffix;
 		}
 		return rejectList;
 	}

--- a/js/reject-feedback.js
+++ b/js/reject-feedback.js
@@ -171,7 +171,7 @@
 				suffix = '</label> <span class="tooltip dashicons dashicons-info" title="' + rejectReasons[ reason ].explanation + '"></span></div>';
 				inputName = 'modal_feedback_reason';
 			}
-			rejectList += prefix + '<input type="checkbox" name="' + inputName + '" value="' + reason + '" />' + rejectReasons[ reason ].name + suffix;
+			rejectList += prefix + '<input type="checkbox" name="' + inputName + '" value="' + reason + '" /> ' + rejectReasons[ reason ].name + suffix;
 		}
 		return rejectList;
 	}

--- a/js/reject-feedback.js
+++ b/js/reject-feedback.js
@@ -168,23 +168,23 @@
 
 	function getReasonList( displayType ) {
 		var rejectReasons = $gp_reject_feedback_settings.reject_reasons;
-
+		var rejectReasonExplanations = $gp_reject_feedback_settings.reject_reason_explanations;
 		var rejectList = '';
 		var prefix = '';
 		var suffix = '';
 		var inputName = '';
-		if ( displayType === 'single' ) {
-			prefix = '<li><label>';
-			suffix = '</label></li>';
-			inputName = 'feedback_reason';
-		} else {
-			prefix = '<div class="modal-item"><label>';
-			suffix = '</div></label>';
-			inputName = 'modal_feedback_reason';
-		}
 
 		// eslint-disable-next-line vars-on-top
 		for ( var reason in rejectReasons ) {
+			if ( displayType === 'single' ) {
+				prefix = '<li><label title="' + rejectReasonExplanations[ reason ] + '">';
+				suffix = '</label></li>';
+				inputName = 'feedback_reason';
+			} else {
+				prefix = '<div class="modal-item"><label title="' + rejectReasonExplanations[ reason ] + '">';
+				suffix = '</div></label>';
+				inputName = 'modal_feedback_reason';
+			}
 			rejectList += prefix + '<input type="checkbox" name="' + inputName + '" value="' + reason + '" />' + rejectReasons[ reason ] + suffix;
 		}
 		return rejectList;

--- a/js/reject-feedback.js
+++ b/js/reject-feedback.js
@@ -100,6 +100,8 @@
 				rejectWithFeedback( rejectData );
 				e.preventDefault();
 			} );
+
+			$( '.tooltip' ).tooltip();
 		}
 	);
 
@@ -177,12 +179,12 @@
 		// eslint-disable-next-line vars-on-top
 		for ( var reason in rejectReasons ) {
 			if ( displayType === 'single' ) {
-				prefix = '<li><label title="' + rejectReasonExplanations[ reason ] + '">';
-				suffix = '</label></li>';
+				prefix = '<li><label class="tooltip" title="' + rejectReasonExplanations[ reason ] + '">';
+				suffix = '</label> <span class="tooltip dashicons dashicons-info" title="' + rejectReasonExplanations[ reason ] + '"></span></li>';
 				inputName = 'feedback_reason';
 			} else {
-				prefix = '<div class="modal-item"><label title="' + rejectReasonExplanations[ reason ] + '">';
-				suffix = '</div></label>';
+				prefix = '<div class="modal-item"><label class="tooltip" title="' + rejectReasonExplanations[ reason ] + '">';
+				suffix = '</label> <span class="tooltip dashicons dashicons-info" title="' + rejectReasonExplanations[ reason ] + '"></span></div>';
 				inputName = 'modal_feedback_reason';
 			}
 			rejectList += prefix + '<input type="checkbox" name="' + inputName + '" value="' + reason + '" />' + rejectReasons[ reason ] + suffix;

--- a/js/reject-feedback.js
+++ b/js/reject-feedback.js
@@ -84,7 +84,9 @@
 				e.preventDefault();
 			} );
 
-			$( '.tooltip' ).tooltip();
+			$( '.tooltip' ).tooltip( {
+				tooltipClass: 'hoverTooltip',
+			} );
 		}
 	);
 

--- a/js/reject-feedback.js
+++ b/js/reject-feedback.js
@@ -9,7 +9,7 @@
 			'<div id="reject-feedback-form" style="display:none;">' +
 			'<form>' +
 			'<h3>Reason</h3>' +
-			getReasonList( 'bulk' ) +
+			getReasonList() +
 			'<div class="modal-comment">' +
 					'<label>Comment </label>' +
 					'<textarea name="modal_feedback_comment"></textarea>' +
@@ -153,7 +153,7 @@
 		);
 	}
 
-	function getReasonList( displayType ) {
+	function getReasonList( ) {
 		var rejectReasons = $gp_reject_feedback_settings.reject_reasons;
 		var rejectList = '';
 		var prefix = '';
@@ -162,15 +162,9 @@
 
 		// eslint-disable-next-line vars-on-top
 		for ( var reason in rejectReasons ) {
-			if ( displayType === 'single' ) {
-				prefix = '<li><label class="tooltip" title="' + rejectReasons[ reason ].explanation + '">';
-				suffix = '</label> <span class="tooltip dashicons dashicons-info" title="' + rejectReasons[ reason ].explanation + '"></span></li>';
-				inputName = 'feedback_reason';
-			} else {
-				prefix = '<div class="modal-item"><label class="tooltip" title="' + rejectReasons[ reason ].explanation + '">';
-				suffix = '</label> <span class="tooltip dashicons dashicons-info" title="' + rejectReasons[ reason ].explanation + '"></span></div>';
-				inputName = 'modal_feedback_reason';
-			}
+			prefix = '<div class="modal-item"><label class="tooltip" title="' + rejectReasons[ reason ].explanation + '">';
+			suffix = '</label> <span class="tooltip dashicons dashicons-info" title="' + rejectReasons[ reason ].explanation + '"></span></div>';
+			inputName = 'modal_feedback_reason';
 			rejectList += prefix + '<input type="checkbox" name="' + inputName + '" value="' + reason + '" /> ' + rejectReasons[ reason ].name + suffix;
 		}
 		return rejectList;

--- a/js/translation-helpers.js
+++ b/js/translation-helpers.js
@@ -146,5 +146,7 @@ jQuery( function( $ ) {
 		};
 	}
 
-	$( '.tooltip' ).tooltip();
+	$( '.tooltip' ).tooltip( {
+		tooltipClass: 'hoverTooltip',
+	} );
 } );

--- a/js/translation-helpers.js
+++ b/js/translation-helpers.js
@@ -145,4 +145,6 @@ jQuery( function( $ ) {
 			} );
 		};
 	}
+
+	$( '.tooltip' ).tooltip();
 } );

--- a/templates/translation-row-editor-meta-feedback.php
+++ b/templates/translation-row-editor-meta-feedback.php
@@ -8,16 +8,15 @@
 			<h3 class="feedback-reason-title">Reason</h3>
 			<ul class="feedback-reason-list">
 			<?php
-				$reject_reasons             = Helper_Translation_Discussion::get_reject_reasons();
-				$reject_reason_explanations = Helper_Translation_Discussion::get_reject_reason_explanations();
+				$reject_reasons = Helper_Translation_Discussion::get_reject_reasons();
 			foreach ( $reject_reasons as $key => $reason ) :
 				?>
 					<li>
-						<label class="tooltip" title="<?php echo esc_attr( $reject_reason_explanations[ $key ], 'glotpress' ); ?>">
+						<label class="tooltip" title="<?php echo esc_attr( $reason['explanation'], 'glotpress' ); ?>">
 							<input type="checkbox" name="feedback_reason" value="<?php echo esc_attr( $key, 'glotpress' ); ?>" />
-							<?php echo esc_html( $reason, 'glotpress' ); ?>
+							<?php echo esc_html( $reason['name'], 'glotpress' ); ?>
 						</label>
-						<span class="tooltip dashicons dashicons-info" title="<?php echo esc_attr( $reject_reason_explanations[ $key ], 'glotpress' ); ?>"></span>
+						<span class="tooltip dashicons dashicons-info" title="<?php echo esc_attr( $reason['explanation'], 'glotpress' ); ?>"></span>
 					</li>
 			<?php endforeach; ?>
 			</ul>

--- a/templates/translation-row-editor-meta-feedback.php
+++ b/templates/translation-row-editor-meta-feedback.php
@@ -12,11 +12,7 @@
 			foreach ( $reject_reasons as $key => $reason ) :
 				?>
 					<li>
-						<label class="tooltip" title="<?php echo esc_attr( $reason['explanation'], 'glotpress' ); ?>">
-							<input type="checkbox" name="feedback_reason" value="<?php echo esc_attr( $key, 'glotpress' ); ?>" />
-							<?php echo esc_html( $reason['name'], 'glotpress' ); ?><span class="tooltip dashicons dashicons-info" title="<?php echo esc_attr( $reason['explanation'], 'glotpress' ); ?>"></span>
-						</label>
-
+						<label class="tooltip" title="<?php echo esc_attr( $reason['explanation'], 'glotpress' ); ?>"><input type="checkbox" name="feedback_reason" value="<?php echo esc_attr( $key, 'glotpress' ); ?>" /><?php echo esc_html( $reason['name'], 'glotpress' ); ?></label><span class="tooltip dashicons dashicons-info" title="<?php echo esc_attr( $reason['explanation'], 'glotpress' ); ?>"></span>
 					</li>
 			<?php endforeach; ?>
 			</ul>

--- a/templates/translation-row-editor-meta-feedback.php
+++ b/templates/translation-row-editor-meta-feedback.php
@@ -13,11 +13,11 @@
 			foreach ( $reject_reasons as $key => $reason ) :
 				?>
 					<li>
-						<label class="tooltip" title="<?php esc_attr_e( $reject_reason_explanations[ $key ], 'glotpress' ); ?>">
-							<input type="checkbox" name="feedback_reason" value="<?php esc_attr_e( $key, 'glotpress' ); ?>" />
-							<?php esc_html_e( $reason, 'glotpress' ); ?>
+						<label class="tooltip" title="<?php echo esc_attr( $reject_reason_explanations[ $key ], 'glotpress' ); ?>">
+							<input type="checkbox" name="feedback_reason" value="<?php echo esc_attr( $key, 'glotpress' ); ?>" />
+							<?php echo esc_html( $reason, 'glotpress' ); ?>
 						</label>
-						<span class="tooltip dashicons dashicons-info" title="<?php esc_attr_e( $reject_reason_explanations[ $key ], 'glotpress' ); ?>"></span>
+						<span class="tooltip dashicons dashicons-info" title="<?php echo esc_attr( $reject_reason_explanations[ $key ], 'glotpress' ); ?>"></span>
 					</li>
 			<?php endforeach; ?>
 			</ul>

--- a/templates/translation-row-editor-meta-feedback.php
+++ b/templates/translation-row-editor-meta-feedback.php
@@ -14,9 +14,9 @@
 					<li>
 						<label class="tooltip" title="<?php echo esc_attr( $reason['explanation'], 'glotpress' ); ?>">
 							<input type="checkbox" name="feedback_reason" value="<?php echo esc_attr( $key, 'glotpress' ); ?>" />
-							<?php echo esc_html( $reason['name'], 'glotpress' ); ?>
+							<?php echo esc_html( $reason['name'], 'glotpress' ); ?><span class="tooltip dashicons dashicons-info" title="<?php echo esc_attr( $reason['explanation'], 'glotpress' ); ?>"></span>
 						</label>
-						<span class="tooltip dashicons dashicons-info" title="<?php echo esc_attr( $reason['explanation'], 'glotpress' ); ?>"></span>
+
 					</li>
 			<?php endforeach; ?>
 			</ul>

--- a/templates/translation-row-editor-meta-feedback.php
+++ b/templates/translation-row-editor-meta-feedback.php
@@ -8,10 +8,17 @@
 			<h3 class="feedback-reason-title">Reason</h3>
 			<ul class="feedback-reason-list">
 			<?php
-				$reject_reasons = Helper_Translation_Discussion::get_reject_reasons();
+				$reject_reasons             = Helper_Translation_Discussion::get_reject_reasons();
+				$reject_reason_explanations = Helper_Translation_Discussion::get_reject_reason_explanations();
 			foreach ( $reject_reasons as $key => $reason ) :
 				?>
-					<li><label><input type="checkbox" name="feedback_reason" value="<?php echo esc_attr( $key ); ?>" /><?php echo esc_html( $reason ); ?></label></li>
+					<li>
+						<label class="tooltip" title="<?php esc_attr_e( $reject_reason_explanations[ $key ], 'glotpress' ); ?>">
+							<input type="checkbox" name="feedback_reason" value="<?php esc_attr_e( $key, 'glotpress' ); ?>" />
+							<?php esc_html_e( $reason, 'glotpress' ); ?>
+						</label>
+						<span class="tooltip dashicons dashicons-info" title="<?php esc_attr_e( $reject_reason_explanations[ $key ], 'glotpress' ); ?>"></span>
+					</li>
 			<?php endforeach; ?>
 			</ul>
 			<div class="feedback-comment">


### PR DESCRIPTION
## Problem

When you are rejecting a string, the reject reasons don't have an explanation. This PR proposes to add a tooltip with explanation for Reject Reasons.

![image](https://user-images.githubusercontent.com/1667814/179506836-fed0a727-6341-48ad-8816-d8f8e3d67489.png)

Solves https://github.com/GlotPress/gp-translation-helpers/issues/81.
<!--
Please describe what is the status/problem before the PR.
-->

## Solution

This PR adds tooltips to the rejection reason, using an array with a description for each rejection reason, both in the individual rejection (sidebar) and in the bulk rejection (popover). See next screenshots.

### Single rejection
![image](https://user-images.githubusercontent.com/1667814/179534977-317a0bd2-603b-4512-a182-b6934cd8c4e4.png)

### Bulk rejection
![image](https://user-images.githubusercontent.com/1667814/179535498-a4519bd6-125e-428d-98df-8148b7fb524f.png)

<!--
Please describe how this PR improves the situation.
-->

## Testing instructions

You need to test it manually:
* Single rejection. Go to "Give feedback" in the sidebar and put the mouse over a reject reason. You will see the tooltip with the explanation.
* Bulk rejection. Reject some translations with the bulk functionality. You will get a popover. Put the mouse over a reject reason. You will see the tooltip with the explanation.
<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

