### PR TITLE
Add button style to reply link

### DIFF
--- a/css/discussion.css
+++ b/css/discussion.css
@@ -222,7 +222,10 @@ div#TB_ajaxWindowTitle {
 	-webkit-box-shadow: none;
 	box-shadow: none;
 }
-
 .hoverTooltip {
 	position: fixed !important;
+}
+
+a.comment-reply-link {
+	margin: 2px !important;
 }

--- a/helpers/helper-translation-discussion.php
+++ b/helpers/helper-translation-discussion.php
@@ -663,7 +663,7 @@ class Helper_Translation_Discussion extends GP_Translation_Helper {
 		$data_attribute_string = trim( $data_attribute_string );
 
 		$link = sprintf(
-			"<a rel='nofollow' class='comment-reply-link' href='%s' %s aria-label='%s'>%s</a>",
+			"<a rel='nofollow' class='comment-reply-link button is-primary' href='%s' %s aria-label='%s'>%s</a>",
 			esc_url(
 				add_query_arg(
 					array(


### PR DESCRIPTION
#### Problem

Reply link on the discussions page was not conspicuous enough. See how it looked below;

#### Solution
Added css classes `button` and `is-primary` to the reply link and it now looks like this, see below;

#### Testing instructions
##### Before
<img width="895" alt="Screenshot 2022-07-21 at 14 22 54" src="https://user-images.githubusercontent.com/2834132/180224989-dfbf0c27-20d2-4d05-b27b-c713b87c25d1.png">

##### After
<img width="887" alt="Screenshot 2022-07-21 at 14 24 40" src="https://user-images.githubusercontent.com/2834132/180224712-b5ba4e8d-0ec3-4383-aa05-c59a69db1b44.png">


