### PR TITLE
Catch the Ajax errors in the reject with feedback

### DIFF
--- a/js/reject-feedback.js
+++ b/js/reject-feedback.js
@@ -158,7 +158,8 @@
 				}
 				msg += '. Please, take a screenshot, send it to the developers, and reload the page to see if it still worked.';
 				$gp.notices.error( msg );
-			} );
+			}
+		);
 	}
 
 	function getReasonList( ) {

--- a/js/reject-feedback.js
+++ b/js/reject-feedback.js
@@ -150,7 +150,15 @@
 					div.find( 'textarea[name="feedback_comment"]' ).val( '' );
 				}
 			}
-		);
+		).fail(
+			function( xhr, msg ) {
+				msg = 'An error has occurred';
+				if ( xhr.responseText ) {
+					msg += ': ' + xhr.responseText;
+				}
+				msg += '. Please, take a screenshot, send it to the developers, and reload the page to see if it still worked.';
+				$gp.notices.error( msg );
+			} );
 	}
 
 	function getReasonList( ) {


### PR DESCRIPTION
## Problem

<!--
Please describe what is the status/problem before the PR.
-->

This PR fixes https://github.com/GlotPress/gp-translation-helpers/issues/68. When the 'Request with feedback' Ajax request fails, the user doesn't get an error message. 

## Solution

This PR adds the error message, to inform the user that the error has happened.

![image](https://user-images.githubusercontent.com/1667814/180955642-769735de-37c9-40da-a553-de6ce2e078f3.png)

<!--
Please describe how this PR improves the situation.
-->

## Testing instructions

To reproduce this error, comment the [nonce in the class-gp-translation-helpers.php](https://github.com/GlotPress/gp-translation-helpers/blob/main/includes/class-gp-translation-helpers.php#L374), so the Ajax request fails due to an incorrect nonce.
![image](https://user-images.githubusercontent.com/1667814/180955933-11df0d9d-c948-4754-be94-153cf69c553c.png)

Then try to reject a single or bulk translation, and you will see the error. 
<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

