### PR TITLE
Apply glotpress style to buttons

### DIFF
--- a/css/discussion.css
+++ b/css/discussion.css
@@ -146,18 +146,33 @@ h6 {
 }
 .modal-btn {
 	float: right;
-	font-size: 15px;
-	height: 35px;
-	line-height: 1;
-	background: #0085ba;
-	border-color: #0073aa #006799 #006799;
-	box-shadow: 0 1px 0 #006799;
-	color: #fff;
-	text-decoration: none;
-	text-shadow: 0 -1px 1px #006799, 1px 0 1px #006799, 0 1px 1px #006799, -1px 0 1px #006799;
-	margin-top: 10px;
-	padding: 0 13px;
-	border-radius: 3px;
+	background-color: var(--gp-color-btn-primary-bg);
+    border-color: var(--gp-color-btn-primary-border);
+    color: var(--gp-color-btn-primary-text);
+	-webkit-appearance: none;
+    appearance: none;
+    display: inline-flex;
+    align-items: center;
+    text-decoration: none;
+    padding: 5px 16px;
+    font-size: 14px;
+    line-height: 20px;
+    font-weight: 500;
+    border: 1px solid var(--gp-color-btn-border);
+    border-radius: 2px;
+    box-shadow: none;
+    min-height: 32px;
+    margin: 0;
+    cursor: pointer;
+    outline: 0;
+    white-space: nowrap;
+    vertical-align: middle;
+}
+.modal-btn:hover {
+	background-color: var(--gp-color-btn-primary-hover-bg);
+    border-color: var(--gp-color-btn-primary-hover-border);
+    color: var(--gp-color-btn-primary-hover-text);
+    box-shadow: 0 0 0 1px var(--gp-color-canvas-default),0 0 0 2px var(--gp-color-btn-primary-hover-border);
 }
 .modal-reason-title{
 	margin-top: 12px;

--- a/css/discussion.css
+++ b/css/discussion.css
@@ -146,6 +146,15 @@ h6 {
 }
 .modal-btn {
 	float: right;
+	
+}
+.gp-btn-style:hover, #respond form .form-submit .submit:hover {
+	background-color: var(--gp-color-btn-primary-hover-bg);
+    border-color: var(--gp-color-btn-primary-hover-border);
+    color: var(--gp-color-btn-primary-hover-text);
+    box-shadow: 0 0 0 1px var(--gp-color-canvas-default),0 0 0 2px var(--gp-color-btn-primary-hover-border);
+}
+.gp-btn-style, #respond form .form-submit .submit{
 	background-color: var(--gp-color-btn-primary-bg);
     border-color: var(--gp-color-btn-primary-border);
     color: var(--gp-color-btn-primary-text);
@@ -168,18 +177,14 @@ h6 {
     white-space: nowrap;
     vertical-align: middle;
 }
-.modal-btn:hover {
-	background-color: var(--gp-color-btn-primary-hover-bg);
-    border-color: var(--gp-color-btn-primary-hover-border);
-    color: var(--gp-color-btn-primary-hover-text);
-    box-shadow: 0 0 0 1px var(--gp-color-canvas-default),0 0 0 2px var(--gp-color-btn-primary-hover-border);
-}
+
 .modal-reason-title{
 	margin-top: 12px;
 	margin-bottom: 10px;
 	padding-top: 10px;
 	padding-bottom: 10px;
 }
+
 #TB_title {
 	background: #f1f1f1;
 	border-bottom: 1px solid #ddd;

--- a/css/discussion.css
+++ b/css/discussion.css
@@ -146,36 +146,35 @@ h6 {
 }
 .modal-btn {
 	float: right;
-	
 }
 .gp-btn-style:hover, #respond form .form-submit .submit:hover {
 	background-color: var(--gp-color-btn-primary-hover-bg);
-    border-color: var(--gp-color-btn-primary-hover-border);
-    color: var(--gp-color-btn-primary-hover-text);
-    box-shadow: 0 0 0 1px var(--gp-color-canvas-default),0 0 0 2px var(--gp-color-btn-primary-hover-border);
+	border-color: var(--gp-color-btn-primary-hover-border);
+	color: var(--gp-color-btn-primary-hover-text);
+	box-shadow: 0 0 0 1px var(--gp-color-canvas-default),0 0 0 2px var(--gp-color-btn-primary-hover-border);
 }
 .gp-btn-style, #respond form .form-submit .submit{
 	background-color: var(--gp-color-btn-primary-bg);
-    border-color: var(--gp-color-btn-primary-border);
-    color: var(--gp-color-btn-primary-text);
+	border-color: var(--gp-color-btn-primary-border);
+	color: var(--gp-color-btn-primary-text);
 	-webkit-appearance: none;
-    appearance: none;
-    display: inline-flex;
-    align-items: center;
-    text-decoration: none;
-    padding: 5px 16px;
-    font-size: 14px;
-    line-height: 20px;
-    font-weight: 500;
-    border: 1px solid var(--gp-color-btn-border);
-    border-radius: 2px;
-    box-shadow: none;
-    min-height: 32px;
-    margin: 0;
-    cursor: pointer;
-    outline: 0;
-    white-space: nowrap;
-    vertical-align: middle;
+	appearance: none;
+	display: inline-flex;
+	align-items: center;
+	text-decoration: none;
+	padding: 5px 16px;
+	font-size: 14px;
+	line-height: 20px;
+	font-weight: 500;
+	border: 1px solid var(--gp-color-btn-border);
+	border-radius: 2px;
+	box-shadow: none;
+	min-height: 32px;
+	margin: 0;
+	cursor: pointer;
+	outline: 0;
+	white-space: nowrap;
+	vertical-align: middle;
 }
 
 .modal-reason-title{

--- a/helpers-assets/templates/translation-discussion-comments.php
+++ b/helpers-assets/templates/translation-discussion-comments.php
@@ -103,6 +103,7 @@
 				'id_form'             => 'commentform-' . $_post_id,
 				'cancel_reply_link'   => '<span></span>',
 				'format'              => 'html5',
+				'class_submit' => 'button is-primary',
 				'comment_notes_after' => implode(
 					"\n",
 					array(

--- a/includes/class-gp-translation-helpers.php
+++ b/includes/class-gp-translation-helpers.php
@@ -363,7 +363,7 @@ class GP_Translation_Helpers {
 			return;
 		}
 
-		wp_register_script( 'gp-reject-feedback-js', plugins_url( '/../js/reject-feedback.js', __FILE__ ), array( 'jquery', 'gp-common', 'gp-editor', 'thickbox' ), '20220722' );
+		wp_register_script( 'gp-reject-feedback-js', plugins_url( '/../js/reject-feedback.js', __FILE__ ), array( 'jquery', 'gp-common', 'gp-editor', 'thickbox' ), '20220726' );
 		gp_enqueue_script( 'gp-reject-feedback-js' );
 
 		wp_localize_script(

--- a/js/reject-feedback.js
+++ b/js/reject-feedback.js
@@ -14,7 +14,7 @@
 					'<label>Comment </label>' +
 					'<textarea name="modal_feedback_comment"></textarea>' +
 			'</div>' +
-			'<button id="modal-reject-btn" class="modal-btn">Reject</button>' +
+			'<button id="modal-reject-btn" class="modal-btn gp-btn-style">Reject</button>' +
 			'</form>' +
 			'</div>';
 


### PR DESCRIPTION
#### Problem
Some of the buttons do not conform to the GlotPress button style.
See before and after screenshots below;

#### Solution
Modify styles to make the buttons conform to GlotPress button styles.

#### Testing instructions

#### Before 
<img width="653" alt="Screenshot 2022-07-26 at 09 30 22" src="https://user-images.githubusercontent.com/2834132/180961468-11807012-bc6c-4e9b-90bb-752f8e9aa037.png">

<img width="670" alt="Screenshot 2022-07-26 at 09 30 10" src="https://user-images.githubusercontent.com/2834132/180961517-5e72254b-943d-4dae-b5cf-0de198813596.png">

<img width="844" alt="image" src="https://user-images.githubusercontent.com/2834132/181038984-b3bb0a8a-e6d9-46ee-9947-74eeb7f9c315.png">


#### After
<img width="699" alt="Screenshot 2022-07-26 at 09 29 19" src="https://user-images.githubusercontent.com/2834132/180961738-acfb1422-1777-4980-b9ca-be26e44e82c9.png">

<img width="694" alt="Screenshot 2022-07-26 at 09 29 38" src="https://user-images.githubusercontent.com/2834132/180961765-e80cc82d-3e7c-4cfc-9c98-670ab9845158.png">

<img width="879" alt="image" src="https://user-images.githubusercontent.com/2834132/181039085-dc7d42be-4cb4-4c8d-b305-560949ce6ec4.png">

 
