### PR TITLE
Show the textarea in a reply to a comment

### DIFF
--- a/helpers/helper-translation-discussion.php
+++ b/helpers/helper-translation-discussion.php
@@ -970,7 +970,6 @@ function gth_discussion_callback( WP_Comment $comment, array $args, int $depth )
 							'title_reply_to'      => esc_html__( 'Reply to %s' ),
 							'title_reply_before'  => '<h5 id="reply-title" class="discuss-title">',
 							'title_reply_after'   => '</h5>',
-							'comment_field'       => '<p class="">',
 							'id_form'             => 'commentform-' . $comment->comment_post_ID,
 							'cancel_reply_link'   => '<span></span>',
 							'comment_notes_after' => implode(


### PR DESCRIPTION
## Problem

The textarea doesn't show up when the reply button is clicked. See screenshot below;

![image](https://user-images.githubusercontent.com/1667814/181069150-5903a920-7ed4-439f-9311-99737bde70c8.png)

Solves https://github.com/GlotPress/gp-translation-helpers/issues/86.
<!--
Please describe what is the status/problem before the PR.
-->

## Solution

This PR removes a comment_field in the comment_form, so the textarea is showed in the reply to a comment.
<!--
Please describe how this PR improves the situation.
-->

## Testing instructions

Go to a discussion page and try to reply to a comment. You will see the form with the textarea and the "Post comment" button. Reply to the comment and click in the button to see the reply stored in the database.

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

