### PR TITLE
Update the options in the select item where we add a new comment in a discussion

### DIFF
--- a/gp-translation-helpers.php
+++ b/gp-translation-helpers.php
@@ -34,6 +34,8 @@ require_once __DIR__ . '/includes/class-gp-translation-helpers.php';
 require_once __DIR__ . '/includes/class-gth-temporary-post.php';
 require_once __DIR__ . '/includes/class-gp-notifications.php';
 require_once __DIR__ . '/includes/class-wporg-notifications.php';
+require_once __DIR__ . '/includes/class-wporg-customizations.php';
 
 add_action( 'gp_init', array( 'GP_Translation_Helpers', 'init' ) );
 add_action( 'gp_init', array( 'WPorg_GlotPress_Notifications', 'init' ) );    // todo: include this class in a different plugin.
+add_action( 'gp_init', array( 'WPorg_GlotPress_Customizations', 'init' ) );    // todo: include this class in a different plugin.

--- a/helpers-assets/templates/translation-discussion-comments.php
+++ b/helpers-assets/templates/translation-discussion-comments.php
@@ -59,56 +59,62 @@
 		?>
 	</ul><!-- .discussion-list -->
 	<?php
-	$option_typo     = '<option value="typo">Typo in the English text (admins will be notified)</option>';
-	$option_context  = '<option value="context">Where does this string appear? (more context) (admins will be notified)</option>';
-	$option_question = '';
+	// $option_typo     = '<option value="typo">Typo in the English text (admins will be notified)</option>';
+	// $option_context  = '<option value="context">Where does this string appear? (more context) (admins will be notified)</option>';
+	$optgroup_question = '';
 	if ( $locale_slug ) {
 		$gp_locale = GP_Locales::by_slug( $locale_slug );
 		if ( $gp_locale ) {
-			$option_question = '<option value="question">Question about translating to ' . esc_html( $gp_locale->english_name ) . ' (validators will be notified)</option>';
+			$optgroup_question = '
+					<optgroup label="Notify validators">
+					    <option value="question">Question about translating to ' . esc_html( $gp_locale->english_name ) . '</option>
+					</optgroup>';
 		}
 	}
+	$options = '<select required="" name="comment_topic" id="comment_topic">
+					<option value="">Select a topic</option>
+					<optgroup label="Notify admins">
+						<option value="typo">Typo in the English text</option>
+						<option value="context">Where does this string appear? (more context)</option>
+					</optgroup>' .
+			   $optgroup_question .
+			   '</select>';
+
 	add_action(
 		'comment_form_logged_in_after',
-		function () use ( $locale_slug, $option_typo, $option_context, $option_question ) {
-
+		function () use ( $locale_slug, $options ) {
 			/**
-			 * Filters the content of the typo option.
+			 * Filters the options.
 			 *
-			 * @since 0.0.2
-			 *
-			 * @param string $option_typo The content of the typo option.
-			 */
-			$option_typo = apply_filters( 'gp_discussion_new_comment_typo', $option_typo );
-
-			/**
-			 * Filters the content of the context option.
-			 *
-			 * @since 0.0.2
-			 *
-			 * @param string $option_context The content of the context option.
-			 */
-			$option_context = apply_filters( 'gp_discussion_new_comment_context', $option_context );
-
-			/**
-			 * Filters the content of the language question option.
-			 *
-			 * @param string $option_question The content of the language question option.
-			 * @param string $locale_slug     The slug of the current locale.
+			 * @param string $options     The options for the select element.
+			 * @param string $locale_slug The slug of the current locale.
 			 *
 			 *@since 0.0.2
 			 */
-			$option_question = apply_filters( 'gp_discussion_new_comment_language_question', $option_question, $locale_slug );
+			$options = apply_filters( 'gp_discussion_new_comment_options', $options, $locale_slug );
 
 			echo '<p class="comment-form-topic">
-					<label for="comment_topic">Topic <span class="required" aria-hidden="true">*</span> (required)</label>
-					<select required name="comment_topic" id="comment_topic">
-						<option value="">Select a topic</option>' .
-						wp_kses( $option_typo, array( 'option' => array( 'value' => true ) ) ) .
-						wp_kses( $option_context, array( 'option' => array( 'value' => true ) ) ) .
-						wp_kses( $option_question, array( 'option' => array( 'value' => true ) ) ) .
-				 '</select>
-    			</p>';
+					<label for="comment_topic">Topic <span class="required" aria-hidden="true">*</span> (required)</label> ' .
+						wp_kses(
+							$options,
+							array(
+								'select'   =>
+										   array(
+											   'required' => true,
+											   'name'     => true,
+											   'id'       => true,
+										   ),
+								'optgroup' =>
+										array(
+											'label' => true,
+										),
+								'option'   =>
+										array(
+											'value' => true,
+										),
+							)
+						) .
+				'</p>';
 		},
 		10,
 		2

--- a/helpers-assets/templates/translation-discussion-comments.php
+++ b/helpers-assets/templates/translation-discussion-comments.php
@@ -59,26 +59,55 @@
 		?>
 	</ul><!-- .discussion-list -->
 	<?php
+	$option_typo     = '<option value="typo">Typo in the English text (admins will be notified)</option>';
+	$option_context  = '<option value="context">Where does this string appear? (more context) (admins will be notified)</option>';
+	$option_question = '';
+	if ( $locale_slug ) {
+		$gp_locale = GP_Locales::by_slug( $locale_slug );
+		if ( $gp_locale ) {
+			$option_question = '<option value="question">Question about translating to ' . esc_html( $gp_locale->english_name ) . ' (validators will be notified)</option>';
+		}
+	}
 	add_action(
 		'comment_form_logged_in_after',
-		function () use ( $locale_slug ) {
-			$language_question = '';
+		function () use ( $locale_slug, $option_typo, $option_context, $option_question ) {
 
-			if ( $locale_slug ) {
-				$gp_locale = GP_Locales::by_slug( $locale_slug );
-				if ( $gp_locale ) {
-					$language_question = '<option value="question">Question about translating to ' . esc_html( $gp_locale->english_name ) . '</option>';
-				}
-			}
+			/**
+			 * Filters the content of the typo option.
+			 *
+			 * @since 0.0.2
+			 *
+			 * @param string $option_typo The content of the typo option.
+			 */
+			$option_typo = apply_filters( 'gp_discussion_new_comment_typo', $option_typo );
+
+			/**
+			 * Filters the content of the context option.
+			 *
+			 * @since 0.0.2
+			 *
+			 * @param string $option_context The content of the context option.
+			 */
+			$option_context = apply_filters( 'gp_discussion_new_comment_context', $option_context );
+
+			/**
+			 * Filters the content of the language question option.
+			 *
+			 * @param string $option_question The content of the language question option.
+			 * @param string $locale_slug     The slug of the current locale.
+			 *
+			 *@since 0.0.2
+			 */
+			$option_question = apply_filters( 'gp_discussion_new_comment_language_question', $option_question, $locale_slug );
 
 			echo '<p class="comment-form-topic">
 					<label for="comment_topic">Topic <span class="required" aria-hidden="true">*</span> (required)</label>
 					<select required name="comment_topic" id="comment_topic">
-						<option value="">Select topic</option>
-						<option value="typo">Typo in the English text</option>
-    					<option value="context">Where does this string appear? (more context)</option>' .
-						wp_kses( $language_question, array( 'option' => array( 'value' => true ) ) ) .
-					'</select>
+						<option value="">Select a topic</option>' .
+						wp_kses( $option_typo, array( 'option' => array( 'value' => true ) ) ) .
+						wp_kses( $option_context, array( 'option' => array( 'value' => true ) ) ) .
+						wp_kses( $option_question, array( 'option' => array( 'value' => true ) ) ) .
+				 '</select>
     			</p>';
 		},
 		10,
@@ -103,7 +132,7 @@
 				'id_form'             => 'commentform-' . $_post_id,
 				'cancel_reply_link'   => '<span></span>',
 				'format'              => 'html5',
-				'class_submit' => 'button is-primary',
+				'class_submit'        => 'button is-primary',
 				'comment_notes_after' => implode(
 					"\n",
 					array(

--- a/includes/class-wporg-customizations.php
+++ b/includes/class-wporg-customizations.php
@@ -16,7 +16,7 @@ class WPorg_GlotPress_Customizations {
 	 * @return void
 	 */
 	public static function init() {
-//		if ( defined( 'WPORG_TRANSLATE_BLOGID' ) && ( get_current_blog_id() === WPORG_TRANSLATE_BLOGID ) ) {
+		if ( defined( 'WPORG_TRANSLATE_BLOGID' ) && ( get_current_blog_id() === WPORG_TRANSLATE_BLOGID ) ) {
 			add_filter(
 				'gp_discussion_new_comment_options',
 				function ( $options, $locale_slug ) {
@@ -44,5 +44,5 @@ class WPorg_GlotPress_Customizations {
 				2
 			);
 		}
-//	}
+	}
 }

--- a/includes/class-wporg-customizations.php
+++ b/includes/class-wporg-customizations.php
@@ -16,37 +16,33 @@ class WPorg_GlotPress_Customizations {
 	 * @return void
 	 */
 	public static function init() {
-		if ( defined( 'WPORG_TRANSLATE_BLOGID' ) && ( get_current_blog_id() === WPORG_TRANSLATE_BLOGID ) ) {
+//		if ( defined( 'WPORG_TRANSLATE_BLOGID' ) && ( get_current_blog_id() === WPORG_TRANSLATE_BLOGID ) ) {
 			add_filter(
-				'gp_discussion_new_comment_typo',
-				function ( $option_typo ) {
-					return '<option value="typo">Typo in the English text (developers will be notified if they have opt-in)</option>';
-				},
-				10,
-				1
-			);
-			add_filter(
-				'gp_discussion_new_comment_context',
-				function ( $option_context ) {
-					return '<option value="context">Where does this string appear? (more context) (developers will be notified if they have opt-in)</option>';
-				},
-				10,
-				1
-			);
-			add_filter(
-				'gp_discussion_new_comment_language_question',
-				function ( $option_question, $locale_slug ) {
+				'gp_discussion_new_comment_options',
+				function ( $options, $locale_slug ) {
+					$optgroup_question = '';
 					if ( $locale_slug ) {
 						$gp_locale = GP_Locales::by_slug( $locale_slug );
 						if ( $gp_locale ) {
-							return '<option value="question">Question about translating to ' . esc_html( $gp_locale->english_name ) . '(GTE/PTE/CLPTE will be notified if they have opt-in)</option>';
+							$optgroup_question = '
+								<optgroup label="Notify GTE/PTE/CLPTE (if opted-in)">
+									<option value="question">Question about translating to ' . esc_html( $gp_locale->english_name ) . '</option>
+								</optgroup>';
 						}
 					}
-					return '';
+
+					return '<select required="" name="comment_topic" id="comment_topic">
+								<option value="">Select a topic</option>
+								<optgroup label="Notify  developers (if opted-in)">
+									<option value="typo">Typo in the English text</option>
+									<option value="context">Where does this string appear? (more context)</option>
+								</optgroup>' .
+								$optgroup_question .
+							'</select>';
 				},
 				10,
 				2
 			);
 		}
-	}
+//	}
 }

--- a/includes/class-wporg-customizations.php
+++ b/includes/class-wporg-customizations.php
@@ -33,7 +33,7 @@ class WPorg_GlotPress_Customizations {
 
 					return '<select required="" name="comment_topic" id="comment_topic">
 								<option value="">Select a topic</option>
-								<optgroup label="Notify  developers (if opted-in)">
+								<optgroup label="Notify developers (if opted-in)">
 									<option value="typo">Typo in the English text</option>
 									<option value="context">Where does this string appear? (more context)</option>
 								</optgroup>' .

--- a/includes/class-wporg-customizations.php
+++ b/includes/class-wporg-customizations.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Routes: WPorg_Customizations class
+ *
+ * Manages the WPorg customizations.
+ *
+ * @package gp-translation-helpers
+ * @since 0.0.2
+ */
+class WPorg_GlotPress_Customizations {
+	/**
+	 * Adds the hooks to modify the options in the select item where we add a new comment in a discussion.
+	 *
+	 * @since 0.0.2
+	 *
+	 * @return void
+	 */
+	public static function init() {
+		if ( defined( 'WPORG_TRANSLATE_BLOGID' ) && ( get_current_blog_id() === WPORG_TRANSLATE_BLOGID ) ) {
+			add_filter(
+				'gp_discussion_new_comment_typo',
+				function ( $option_typo ) {
+					return '<option value="typo">Typo in the English text (developers will be notified if they have opt-in)</option>';
+				},
+				10,
+				1
+			);
+			add_filter(
+				'gp_discussion_new_comment_context',
+				function ( $option_context ) {
+					return '<option value="context">Where does this string appear? (more context) (developers will be notified if they have opt-in)</option>';
+				},
+				10,
+				1
+			);
+			add_filter(
+				'gp_discussion_new_comment_language_question',
+				function ( $option_question, $locale_slug ) {
+					if ( $locale_slug ) {
+						$gp_locale = GP_Locales::by_slug( $locale_slug );
+						if ( $gp_locale ) {
+							return '<option value="question">Question about translating to ' . esc_html( $gp_locale->english_name ) . '(GTE/PTE/CLPTE will be notified if they have opt-in)</option>';
+						}
+					}
+					return '';
+				},
+				10,
+				2
+			);
+		}
+	}
+}


### PR DESCRIPTION
## Problem

<!--
Please describe what is the status/problem before the PR.
-->

In the select item where we add a new comment in a discussion, we don't show who will receive a notification.

See https://github.com/GlotPress/gp-translation-helpers/issues/71. 

![image](https://user-images.githubusercontent.com/1667814/181089557-9f4e8be8-3932-465c-b127-e3b8a8a83b8d.png)

## Solution

This PR adds info about who will receive the notifications in GlotPress and 3 filters to modify the options in the select item, so we can change it at translate.w.org.

### GlotPress messages

These are the default messages:

![image](https://user-images.githubusercontent.com/1667814/181496082-7da20266-6545-49b0-b365-fb48e3342959.png)

### translate.w.org messages

These are the messages updates using the hooks:

![image](https://user-images.githubusercontent.com/1667814/181496299-e591e5c5-da29-41ce-9ec8-41eaff298b50.png)

The PR adds a new class that will update this info at translate.w.org.
<!--
Please describe how this PR improves the situation.
-->

## Testing instructions

Go to a discussion page and try to add a comment. You will see the new messages in the select element. If you want to test the translate.w.org messages without a sandbox, you can [comment this check](https://github.com/GlotPress/gp-translation-helpers/blob/clarify-notifications/includes/class-wporg-customizations.php#L19) and the closing curly bracket (}): 

`if ( defined( 'WPORG_TRANSLATE_BLOGID' ) && ( get_current_blog_id() === WPORG_TRANSLATE_BLOGID ) ) {
`
<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

