### PR TITLE
Allow to add a comment and approve or fuzzy the translation

### DIFF
--- a/helpers/helper-translation-discussion.php
+++ b/helpers/helper-translation-discussion.php
@@ -718,13 +718,13 @@ class Helper_Translation_Discussion extends GP_Translation_Helper {
 	}
 
 	/**
-	 * Return an array of allowed updated reasons and explanation of each reason.
+	 * Return an array of allowed comment reasons and explanation of each reason.
 	 *
 	 * @since 0.0.2
 	 *
 	 * @return array
 	 */
-	public static function get_update_reasons(): array {
+	public static function get_comment_reasons(): array {
 		return array(
 			'style'       => array(
 				'name'        => __( 'Style Guide' ),
@@ -823,10 +823,10 @@ function gth_discussion_callback( WP_Comment $comment, array $args, int $depth )
 	$current_translation_id = $args['translation_id'];
 	$comment_translation_id = get_comment_meta( $comment->comment_ID, 'translation_id', true );
 
-	$update_reason = get_comment_meta( $comment->comment_ID, 'reject_reason', true );
+	$comment_reason = get_comment_meta( $comment->comment_ID, 'reject_reason', true );
 
 	$classes = array( 'comment-locale-' . $comment_locale );
-	if ( ! empty( $update_reason ) ) {
+	if ( ! empty( $comment_reason ) ) {
 		$classes[] = 'rejection-feedback';
 		$classes[] = 'rejection-feedback-' . $comment_locale;
 	}
@@ -875,7 +875,7 @@ function gth_discussion_callback( WP_Comment $comment, array $args, int $depth )
 				$linked_comment = str_replace( $parts['path'], $parts['path'] . '/' . $current_locale . '/default', $linked_comment );
 			}
 
-			if ( $update_reason ) :
+			if ( $comment_reason ) :
 				?>
 				The translation <?php gth_print_translation( $comment_translation_id, $args ); ?> <a href="<?php echo esc_url( $linked_comment ); ?>"><?php esc_html_e( 'is being discussed here' ); ?></a>.
 			<?php else : ?>
@@ -883,20 +883,20 @@ function gth_discussion_callback( WP_Comment $comment, array $args, int $depth )
 			<?php endif; ?>
 		<?php else : ?>
 			<?php comment_text(); ?>
-			<?php if ( $update_reason ) : ?>
+			<?php if ( $comment_reason ) : ?>
 			<p>
-				<?php echo esc_html( _n( 'Comment Reason: ', 'Comment Reasons: ', count( $update_reason ) ) ); ?>
+				<?php echo esc_html( _n( 'Comment Reason: ', 'Comment Reasons: ', count( $comment_reason ) ) ); ?>
 				<?php
-				$number_of_items = count( $update_reason );
+				$number_of_items = count( $comment_reason );
 				$counter         = 0;
-				$update_reasons  = Helper_Translation_Discussion::get_update_reasons();
-				foreach ( $update_reason as $reason ) {
+				$comment_reasons = Helper_Translation_Discussion::get_comment_reasons();
+				foreach ( $comment_reason as $reason ) {
 					echo wp_kses(
 						sprintf(
-						/* translators: 1: Title with the explanation of the update reason , 2: The update reason */
+						/* translators: 1: Title with the explanation of the comment reason , 2: The comment reason */
 							__( '<span title="%1$s" class="tooltip">%2$s</span> <span class="tooltip dashicons dashicons-info" title="%1$s"></span>', 'glotpress' ),
-							$update_reasons[ $reason ]['explanation'],
-							$update_reasons[ $reason ]['name'],
+							$comment_reasons[ $reason ]['explanation'],
+							$comment_reasons[ $reason ]['name'],
 						),
 						array(
 							'span' => array(

--- a/helpers/helper-translation-discussion.php
+++ b/helpers/helper-translation-discussion.php
@@ -877,7 +877,7 @@ function gth_discussion_callback( WP_Comment $comment, array $args, int $depth )
 
 			if ( $reject_reason ) :
 				?>
-				The translation <?php gth_print_translation( $comment_translation_id, $args ); ?> was rejected with <a href="<?php echo esc_url( $linked_comment ); ?>"><?php esc_html_e( 'a reason that is being discussed here' ); ?></a>.
+				The translation <?php gth_print_translation( $comment_translation_id, $args ); ?> <a href="<?php echo esc_url( $linked_comment ); ?>"><?php esc_html_e( 'is being discussed here' ); ?></a>.
 			<?php else : ?>
 				<a href="<?php echo esc_url( $linked_comment ); ?>"><?php esc_html_e( 'Please continue the discussion here' ); ?></a>
 			<?php endif; ?>
@@ -885,7 +885,7 @@ function gth_discussion_callback( WP_Comment $comment, array $args, int $depth )
 			<?php comment_text(); ?>
 			<?php if ( $reject_reason ) : ?>
 			<p>
-				<?php echo esc_html( _n( 'Rejection Reason: ', 'Rejection Reasons: ', count( $reject_reason ) ) ); ?>
+				<?php echo esc_html( _n( 'Comment Reason: ', 'Comment Reasons: ', count( $reject_reason ) ) ); ?>
 				<?php
 				$number_of_items = count( $reject_reason );
 				$counter         = 0;
@@ -956,7 +956,7 @@ function gth_discussion_callback( WP_Comment $comment, array $args, int $depth )
 
 			if ( ! $is_linking_comment ) :
 				if ( $comment_translation_id && $comment_translation_id !== $current_translation_id ) {
-					gth_print_translation( $comment_translation_id, $args, empty( $reject_reason ) ? 'Translation: ' : 'Translation  (Rejected): ' );
+					gth_print_translation( $comment_translation_id, $args, 'Translation: ' );
 				}
 
 				?>

--- a/helpers/helper-translation-discussion.php
+++ b/helpers/helper-translation-discussion.php
@@ -699,11 +699,11 @@ class Helper_Translation_Discussion extends GP_Translation_Helper {
 	/**
 	 * Throws an exception with an error message if the original id is incorrect.
 	 *
-	 * Used as callback to validate the original_id passed on rejecting a string with feedback
+	 * Used as callback to validate the original_id passed on updating a string with feedback
 	 *
 	 * @since 0.0.2
 	 *
-	 * @param int|string $original_id   The id of the original for the rejected translation.
+	 * @param int|string $original_id   The id of the original for the updated translation.
 	 *
 	 * @return int|string
 	 *
@@ -718,13 +718,13 @@ class Helper_Translation_Discussion extends GP_Translation_Helper {
 	}
 
 	/**
-	 * Return an array of allowed rejection reasons and explanation of each reason.
+	 * Return an array of allowed updated reasons and explanation of each reason.
 	 *
 	 * @since 0.0.2
 	 *
 	 * @return array
 	 */
-	public static function get_reject_reasons(): array {
+	public static function get_update_reasons(): array {
 		return array(
 			'style'       => array(
 				'name'        => __( 'Style Guide' ),
@@ -823,10 +823,10 @@ function gth_discussion_callback( WP_Comment $comment, array $args, int $depth )
 	$current_translation_id = $args['translation_id'];
 	$comment_translation_id = get_comment_meta( $comment->comment_ID, 'translation_id', true );
 
-	$reject_reason = get_comment_meta( $comment->comment_ID, 'reject_reason', true );
+	$update_reason = get_comment_meta( $comment->comment_ID, 'reject_reason', true );
 
 	$classes = array( 'comment-locale-' . $comment_locale );
-	if ( ! empty( $reject_reason ) ) {
+	if ( ! empty( $update_reason ) ) {
 		$classes[] = 'rejection-feedback';
 		$classes[] = 'rejection-feedback-' . $comment_locale;
 	}
@@ -875,7 +875,7 @@ function gth_discussion_callback( WP_Comment $comment, array $args, int $depth )
 				$linked_comment = str_replace( $parts['path'], $parts['path'] . '/' . $current_locale . '/default', $linked_comment );
 			}
 
-			if ( $reject_reason ) :
+			if ( $update_reason ) :
 				?>
 				The translation <?php gth_print_translation( $comment_translation_id, $args ); ?> <a href="<?php echo esc_url( $linked_comment ); ?>"><?php esc_html_e( 'is being discussed here' ); ?></a>.
 			<?php else : ?>
@@ -883,20 +883,20 @@ function gth_discussion_callback( WP_Comment $comment, array $args, int $depth )
 			<?php endif; ?>
 		<?php else : ?>
 			<?php comment_text(); ?>
-			<?php if ( $reject_reason ) : ?>
+			<?php if ( $update_reason ) : ?>
 			<p>
-				<?php echo esc_html( _n( 'Comment Reason: ', 'Comment Reasons: ', count( $reject_reason ) ) ); ?>
+				<?php echo esc_html( _n( 'Comment Reason: ', 'Comment Reasons: ', count( $update_reason ) ) ); ?>
 				<?php
-				$number_of_items = count( $reject_reason );
+				$number_of_items = count( $update_reason );
 				$counter         = 0;
-				$reject_reasons  = Helper_Translation_Discussion::get_reject_reasons();
-				foreach ( $reject_reason as $reason ) {
+				$update_reasons  = Helper_Translation_Discussion::get_update_reasons();
+				foreach ( $update_reason as $reason ) {
 					echo wp_kses(
 						sprintf(
-						/* translators: 1: Title with the explanation of the reject reason , 2: The reject reason */
+						/* translators: 1: Title with the explanation of the update reason , 2: The update reason */
 							__( '<span title="%1$s" class="tooltip">%2$s</span> <span class="tooltip dashicons dashicons-info" title="%1$s"></span>', 'glotpress' ),
-							$reject_reasons[ $reason ]['explanation'],
-							$reject_reasons[ $reason ]['name'],
+							$update_reasons[ $reason ]['explanation'],
+							$update_reasons[ $reason ]['name'],
 						),
 						array(
 							'span' => array(

--- a/includes/class-gp-translation-helpers.php
+++ b/includes/class-gp-translation-helpers.php
@@ -60,8 +60,8 @@ class GP_Translation_Helpers {
 		add_action( 'gp_before_request', array( $this, 'before_request' ), 10, 2 );
 		add_action( 'rest_after_insert_comment', array( 'GP_Notifications', 'init' ), 10, 3 );
 		add_action( 'transition_comment_status', array( 'GP_Notifications', 'on_comment_status_change' ), 10, 3 );
-		add_action( 'gp_pre_tmpl_load', array( $this, 'register_update_feedback_js' ), 10, 2 );
-		add_action( 'wp_ajax_update_with_feedback', array( $this, 'update_with_feedback' ) );
+		add_action( 'gp_pre_tmpl_load', array( $this, 'register_comment_feedback_js' ), 10, 2 );
+		add_action( 'wp_ajax_comment_with_feedback', array( $this, 'comment_with_feedback' ) );
 		add_action( 'wp_ajax_optout_discussion_notifications', array( $this, 'optout_discussion_notifications' ) );
 
 		add_thickbox();
@@ -357,52 +357,52 @@ class GP_Translation_Helpers {
 	 *
 	 * @return void
 	 */
-	public function register_update_feedback_js( $template, $translation_set ) {
+	public function register_comment_feedback_js( $template, $translation_set ) {
 
 		if ( 'translations' !== $template ) {
 			return;
 		}
 
-		wp_register_script( 'gp-update-feedback-js', plugins_url( '/../js/reject-feedback.js', __FILE__ ), array( 'jquery', 'gp-common', 'gp-editor', 'thickbox' ), '20220726' );
-		gp_enqueue_script( 'gp-update-feedback-js' );
+		wp_register_script( 'gp-comment-feedback-js', plugins_url( '/../js/reject-feedback.js', __FILE__ ), array( 'jquery', 'gp-common', 'gp-editor', 'thickbox' ), '20220726' );
+		gp_enqueue_script( 'gp-comment-feedback-js' );
 
 		wp_localize_script(
-			'gp-update-feedback-js',
-			'$gp_update_feedback_settings',
+			'gp-comment-feedback-js',
+			'$gp_comment_feedback_settings',
 			array(
-				'url'            => admin_url( 'admin-ajax.php' ),
-				'nonce'          => wp_create_nonce( 'gp_update_feedback' ),
-				'locale_slug'    => $translation_set['locale_slug'],
-				'update_reasons' => Helper_Translation_Discussion::get_update_reasons(),
+				'url'             => admin_url( 'admin-ajax.php' ),
+				'nonce'           => wp_create_nonce( 'gp_comment_feedback' ),
+				'locale_slug'     => $translation_set['locale_slug'],
+				'comment_reasons' => Helper_Translation_Discussion::get_comment_reasons(),
 			)
 		);
 	}
 
 	/**
-	 * Is called from the AJAX request in reject-feedback.js to submit an update feedback.
+	 * Is called from the AJAX request in reject-feedback.js to submit an comment feedback.
 	 *
 	 * @since 0.0.2
 	 *
 	 * @return void
 	 */
-	public function update_with_feedback() {
-		check_ajax_referer( 'gp_update_feedback', 'nonce' );
+	public function comment_with_feedback() {
+		check_ajax_referer( 'gp_comment_feedback', 'nonce' );
 
 		$helper_discussion    = new Helper_Translation_Discussion();
 		$locale_slug          = $helper_discussion->sanitize_comment_locale( sanitize_text_field( $_POST['data']['locale_slug'] ) );
 		$translation_id_array = ! empty( $_POST['data']['translation_id'] ) ? array_map( array( $helper_discussion, 'sanitize_translation_id' ), $_POST['data']['translation_id'] ) : null;
 		$original_id_array    = ! empty( $_POST['data']['original_id'] ) ? array_map( array( $helper_discussion, 'sanitize_original_id' ), $_POST['data']['original_id'] ) : null;
-		$update_reason        = ! empty( $_POST['data']['reason'] ) ? $_POST['data']['reason'] : array( 'other' );
-		$all_update_reasons   = array_keys( Helper_Translation_Discussion::get_update_reasons() );
-		$update_reason        = array_filter(
-			$update_reason,
-			function( $reason ) use ( $all_update_reasons ) {
-				return in_array( $reason, $all_update_reasons );
+		$comment_reason       = ! empty( $_POST['data']['reason'] ) ? $_POST['data']['reason'] : array( 'other' );
+		$all_comment_reasons  = array_keys( Helper_Translation_Discussion::get_comment_reasons() );
+		$comment_reason       = array_filter(
+			$comment_reason,
+			function( $reason ) use ( $all_comment_reasons ) {
+				return in_array( $reason, $all_comment_reasons );
 			}
 		);
-		$update_comment       = sanitize_text_field( $_POST['data']['comment'] );
+		$comment              = sanitize_text_field( $_POST['data']['comment'] );
 
-		if ( ! $locale_slug || ! $translation_id_array || ! $original_id_array || ( ! $update_reason && ! $update_comment ) ) {
+		if ( ! $locale_slug || ! $translation_id_array || ! $original_id_array || ( ! $comment_reason && ! $comment ) ) {
 			wp_send_json_error();
 		}
 
@@ -411,13 +411,13 @@ class GP_Translation_Helpers {
 		$first_translation_id = array_shift( $translation_id_array );
 
 		// Post comment on discussion page for the first string
-		$first_comment_id = $this->insert_update_comment( $update_comment, $first_original_id, $update_reason, $first_translation_id, $locale_slug, $_SERVER );
+		$first_comment_id = $this->insert_comment( $comment, $first_original_id, $comment_reason, $first_translation_id, $locale_slug, $_SERVER );
 
 		if ( ! empty( $original_id_array ) && ! empty( $translation_id_array ) ) {
 			// For other strings post link to the comment.
-			$update_comment = get_comment_link( $first_comment_id );
+			$comment = get_comment_link( $first_comment_id );
 			foreach ( $original_id_array as $index => $single_original_id ) {
-				$comment_id = $this->insert_update_comment( $update_comment, $single_original_id, $update_reason, $translation_id_array[ $index ], $locale_slug, $_SERVER );
+				$comment_id = $this->insert_comment( $comment, $single_original_id, $comment_reason, $translation_id_array[ $index ], $locale_slug, $_SERVER );
 				$comment    = get_comment( $comment_id );
 				GP_Notifications::add_related_comment( $comment );
 			}
@@ -465,17 +465,17 @@ class GP_Translation_Helpers {
 	/**
 	 * Inserts feedback as WordPress comment.
 	 *
-	 *  @param string $update_comment Feedback entered by reviewer.
+	 *  @param string $comment        Feedback entered by reviewer.
 	 *  @param int    $original_id    ID of the original where the comment will be added.
-	 *  @param array  $update_reason  Reason(s) for update.
-	 *  @param string $translation_id ID of the updated translation.
-	 *  @param string $locale_slug    Locale of the updated translation.
+	 *  @param array  $reason         Reason(s) for comment.
+	 *  @param string $translation_id ID of the commented translation.
+	 *  @param string $locale_slug    Locale of the commented translation.
 	 *  @param array  $server         The $_SERVER array
 	 *
 	 * @return false|int
 	 * @since 0.0.2
 	 */
-	private function insert_update_comment( $update_comment, $original_id, $update_reason, $translation_id, $locale_slug, $server ) {
+	private function insert_comment( $comment, $original_id, $reason, $translation_id, $locale_slug, $server ) {
 		$post_id = Helper_Translation_Discussion::get_or_create_shadow_post_id( $original_id );
 		$user    = wp_get_current_user();
 		return wp_insert_comment(
@@ -485,11 +485,11 @@ class GP_Translation_Helpers {
 				'comment_author_email' => $user->user_email,
 				'comment_author_url'   => $user->user_url,
 				'comment_author_IP'    => sanitize_text_field( $server['REMOTE_ADDR'] ),
-				'comment_content'      => $update_comment,
+				'comment_content'      => $comment,
 				'comment_agent'        => sanitize_text_field( $server['HTTP_USER_AGENT'] ),
 				'user_id'              => $user->ID,
 				'comment_meta'         => array(
-					'reject_reason'  => $update_reason,
+					'reject_reason'  => $reason,
 					'translation_id' => $translation_id,
 					'locale'         => $locale_slug,
 				),

--- a/includes/class-gp-translation-helpers.php
+++ b/includes/class-gp-translation-helpers.php
@@ -60,8 +60,8 @@ class GP_Translation_Helpers {
 		add_action( 'gp_before_request', array( $this, 'before_request' ), 10, 2 );
 		add_action( 'rest_after_insert_comment', array( 'GP_Notifications', 'init' ), 10, 3 );
 		add_action( 'transition_comment_status', array( 'GP_Notifications', 'on_comment_status_change' ), 10, 3 );
-		add_action( 'gp_pre_tmpl_load', array( $this, 'register_reject_feedback_js' ), 10, 2 );
-		add_action( 'wp_ajax_reject_with_feedback', array( $this, 'reject_with_feedback' ) );
+		add_action( 'gp_pre_tmpl_load', array( $this, 'register_update_feedback_js' ), 10, 2 );
+		add_action( 'wp_ajax_update_with_feedback', array( $this, 'update_with_feedback' ) );
 		add_action( 'wp_ajax_optout_discussion_notifications', array( $this, 'optout_discussion_notifications' ) );
 
 		add_thickbox();
@@ -357,52 +357,52 @@ class GP_Translation_Helpers {
 	 *
 	 * @return void
 	 */
-	public function register_reject_feedback_js( $template, $translation_set ) {
+	public function register_update_feedback_js( $template, $translation_set ) {
 
 		if ( 'translations' !== $template ) {
 			return;
 		}
 
-		wp_register_script( 'gp-reject-feedback-js', plugins_url( '/../js/reject-feedback.js', __FILE__ ), array( 'jquery', 'gp-common', 'gp-editor', 'thickbox' ), '20220726' );
-		gp_enqueue_script( 'gp-reject-feedback-js' );
+		wp_register_script( 'gp-update-feedback-js', plugins_url( '/../js/reject-feedback.js', __FILE__ ), array( 'jquery', 'gp-common', 'gp-editor', 'thickbox' ), '20220726' );
+		gp_enqueue_script( 'gp-update-feedback-js' );
 
 		wp_localize_script(
-			'gp-reject-feedback-js',
-			'$gp_reject_feedback_settings',
+			'gp-update-feedback-js',
+			'$gp_update_feedback_settings',
 			array(
 				'url'            => admin_url( 'admin-ajax.php' ),
-				'nonce'          => wp_create_nonce( 'gp_reject_feedback' ),
+				'nonce'          => wp_create_nonce( 'gp_update_feedback' ),
 				'locale_slug'    => $translation_set['locale_slug'],
-				'reject_reasons' => Helper_Translation_Discussion::get_reject_reasons(),
+				'update_reasons' => Helper_Translation_Discussion::get_update_reasons(),
 			)
 		);
 	}
 
 	/**
-	 * Is called from the AJAX request in reject-feedback.js to submit a rejection feedback.
+	 * Is called from the AJAX request in reject-feedback.js to submit an update feedback.
 	 *
 	 * @since 0.0.2
 	 *
 	 * @return void
 	 */
-	public function reject_with_feedback() {
-		check_ajax_referer( 'gp_reject_feedback', 'nonce' );
+	public function update_with_feedback() {
+		check_ajax_referer( 'gp_update_feedback', 'nonce' );
 
 		$helper_discussion    = new Helper_Translation_Discussion();
 		$locale_slug          = $helper_discussion->sanitize_comment_locale( sanitize_text_field( $_POST['data']['locale_slug'] ) );
 		$translation_id_array = ! empty( $_POST['data']['translation_id'] ) ? array_map( array( $helper_discussion, 'sanitize_translation_id' ), $_POST['data']['translation_id'] ) : null;
 		$original_id_array    = ! empty( $_POST['data']['original_id'] ) ? array_map( array( $helper_discussion, 'sanitize_original_id' ), $_POST['data']['original_id'] ) : null;
-		$reject_reason        = ! empty( $_POST['data']['reason'] ) ? $_POST['data']['reason'] : array( 'other' );
-		$all_reject_reasons   = array_keys( Helper_Translation_Discussion::get_reject_reasons() );
-		$reject_reason        = array_filter(
-			$reject_reason,
-			function( $reason ) use ( $all_reject_reasons ) {
-				return in_array( $reason, $all_reject_reasons );
+		$update_reason        = ! empty( $_POST['data']['reason'] ) ? $_POST['data']['reason'] : array( 'other' );
+		$all_update_reasons   = array_keys( Helper_Translation_Discussion::get_update_reasons() );
+		$update_reason        = array_filter(
+			$update_reason,
+			function( $reason ) use ( $all_update_reasons ) {
+				return in_array( $reason, $all_update_reasons );
 			}
 		);
-		$reject_comment       = sanitize_text_field( $_POST['data']['comment'] );
+		$update_comment       = sanitize_text_field( $_POST['data']['comment'] );
 
-		if ( ! $locale_slug || ! $translation_id_array || ! $original_id_array || ( ! $reject_reason && ! $reject_comment ) ) {
+		if ( ! $locale_slug || ! $translation_id_array || ! $original_id_array || ( ! $update_reason && ! $update_comment ) ) {
 			wp_send_json_error();
 		}
 
@@ -411,13 +411,13 @@ class GP_Translation_Helpers {
 		$first_translation_id = array_shift( $translation_id_array );
 
 		// Post comment on discussion page for the first string
-		$first_comment_id = $this->insert_reject_comment( $reject_comment, $first_original_id, $reject_reason, $first_translation_id, $locale_slug, $_SERVER );
+		$first_comment_id = $this->insert_update_comment( $update_comment, $first_original_id, $update_reason, $first_translation_id, $locale_slug, $_SERVER );
 
 		if ( ! empty( $original_id_array ) && ! empty( $translation_id_array ) ) {
 			// For other strings post link to the comment.
-			$reject_comment = get_comment_link( $first_comment_id );
+			$update_comment = get_comment_link( $first_comment_id );
 			foreach ( $original_id_array as $index => $single_original_id ) {
-				$comment_id = $this->insert_reject_comment( $reject_comment, $single_original_id, $reject_reason, $translation_id_array[ $index ], $locale_slug, $_SERVER );
+				$comment_id = $this->insert_update_comment( $update_comment, $single_original_id, $update_reason, $translation_id_array[ $index ], $locale_slug, $_SERVER );
 				$comment    = get_comment( $comment_id );
 				GP_Notifications::add_related_comment( $comment );
 			}
@@ -463,20 +463,19 @@ class GP_Translation_Helpers {
 	}
 
 	/**
-	 * Inserts rejection feedback as WordPress comment
+	 * Inserts feedback as WordPress comment.
 	 *
-	 * @since 0.0.2
-	 *
-	 *  @param string $reject_comment Feedback entered by reviewer.
-	 *  @param int    $original_id ID of the original where the comment will be added.
-	 *  @param array  $reject_reason Reason(s) for rejection.
-	 *  @param string $translation_id ID of the rejected translation.
-	 *  @param string $locale_slug    Locale of the rejected translation.
+	 *  @param string $update_comment Feedback entered by reviewer.
+	 *  @param int    $original_id    ID of the original where the comment will be added.
+	 *  @param array  $update_reason  Reason(s) for update.
+	 *  @param string $translation_id ID of the updated translation.
+	 *  @param string $locale_slug    Locale of the updated translation.
 	 *  @param array  $server         The $_SERVER array
 	 *
 	 * @return false|int
+	 * @since 0.0.2
 	 */
-	private function insert_reject_comment( $reject_comment, $original_id, $reject_reason, $translation_id, $locale_slug, $server ) {
+	private function insert_update_comment( $update_comment, $original_id, $update_reason, $translation_id, $locale_slug, $server ) {
 		$post_id = Helper_Translation_Discussion::get_or_create_shadow_post_id( $original_id );
 		$user    = wp_get_current_user();
 		return wp_insert_comment(
@@ -486,11 +485,11 @@ class GP_Translation_Helpers {
 				'comment_author_email' => $user->user_email,
 				'comment_author_url'   => $user->user_url,
 				'comment_author_IP'    => sanitize_text_field( $server['REMOTE_ADDR'] ),
-				'comment_content'      => $reject_comment,
+				'comment_content'      => $update_comment,
 				'comment_agent'        => sanitize_text_field( $server['HTTP_USER_AGENT'] ),
 				'user_id'              => $user->ID,
 				'comment_meta'         => array(
-					'reject_reason'  => $reject_reason,
+					'reject_reason'  => $update_reason,
 					'translation_id' => $translation_id,
 					'locale'         => $locale_slug,
 				),

--- a/js/reject-feedback.js
+++ b/js/reject-feedback.js
@@ -90,6 +90,63 @@
 		}
 	);
 
+	$gp.editor.hooks.set_status_current = function() {
+		var button = $( this );
+		var rejectData = {};
+		var rejectReason = [];
+		var comment = '';
+		var div = button.closest( 'div.meta' );
+
+		div.find( 'input[name="feedback_reason"]:checked' ).each(
+			function() {
+				rejectReason.push( this.value );
+			}
+		);
+
+		comment = div.find( 'textarea[name="feedback_comment"]' ).val();
+
+		if ( ! comment.trim().length && ! rejectReason.length ) {
+			$gp.editor.set_status( button, 'current' );
+			return;
+		}
+
+		rejectData.locale_slug = $gp_reject_feedback_settings.locale_slug;
+		rejectData.reason = rejectReason;
+		rejectData.comment = comment;
+		rejectData.original_id = [ $gp.editor.current.original_id ];
+		rejectData.translation_id = [ $gp.editor.current.translation_id ];
+
+		rejectWithFeedback( rejectData, button, 'current' );
+	};
+	$gp.editor.hooks.set_status_fuzzy = function() {
+		var button = $( this );
+		var rejectData = {};
+		var rejectReason = [];
+		var comment = '';
+		var div = button.closest( 'div.meta' );
+
+		div.find( 'input[name="feedback_reason"]:checked' ).each(
+			function() {
+				rejectReason.push( this.value );
+			}
+		);
+
+		comment = div.find( 'textarea[name="feedback_comment"]' ).val();
+
+		if ( ! comment.trim().length && ! rejectReason.length ) {
+			$gp.editor.set_status( button, 'fuzzy' );
+			return;
+		}
+
+		rejectData.locale_slug = $gp_reject_feedback_settings.locale_slug;
+		rejectData.reason = rejectReason;
+		rejectData.comment = comment;
+		rejectData.original_id = [ $gp.editor.current.original_id ];
+		rejectData.translation_id = [ $gp.editor.current.translation_id ];
+
+		rejectWithFeedback( rejectData, button, 'fuzzy' );
+	};
+
 	$gp.editor.hooks.set_status_rejected = function() {
 		var button = $( this );
 		var rejectData = {};
@@ -116,10 +173,10 @@
 		rejectData.original_id = [ $gp.editor.current.original_id ];
 		rejectData.translation_id = [ $gp.editor.current.translation_id ];
 
-		rejectWithFeedback( rejectData, button );
+		rejectWithFeedback( rejectData, button, 'rejected' );
 	};
 
-	function rejectWithFeedback( rejectData, button ) {
+	function rejectWithFeedback( rejectData, button, status ) {
 		var data = {};
 		var div = {};
 		if ( button ) {
@@ -145,7 +202,7 @@
 				if ( rejectData.is_bulk_reject ) {
 					$( 'form.filters-toolbar.bulk-actions, form#bulk-actions-toolbar-top' ).submit();
 				} else {
-					$gp.editor.set_status( button, 'rejected' );
+					$gp.editor.set_status( button, status );
 					div.find( 'input[name="feedback_reason"]' ).prop( 'checked', false );
 					div.find( 'textarea[name="feedback_comment"]' ).val( '' );
 				}

--- a/js/reject-feedback.js
+++ b/js/reject-feedback.js
@@ -1,4 +1,4 @@
-/* global $gp, $gp_update_feedback_settings, document, tb_show */
+/* global $gp, $gp_comment_feedback_settings, document, tb_show */
 ( function( $, $gp ) {
 	$( document ).ready(
 		function() {
@@ -58,29 +58,29 @@
 
 			$( 'body' ).on( 'click', '#modal-reject-btn', function( e ) {
 				var comment = '';
-				var updateReason = [];
-				var updateData = {};
+				var commentReason = [];
+				var commentData = {};
 				var form = $( this ).closest( 'form' );
 
 				form.find( 'input[name="modal_feedback_reason"]:checked' ).each(
 					function() {
-						updateReason.push( this.value );
+						commentReason.push( this.value );
 					}
 				);
 
 				comment = form.find( 'textarea[name="modal_feedback_comment"]' ).val();
 
-				if ( ( ! comment.trim().length && ! updateReason.length ) || ( ! translationIds.length || ! originalIds.length ) ) {
+				if ( ( ! comment.trim().length && ! commentReason.length ) || ( ! translationIds.length || ! originalIds.length ) ) {
 					$( 'form.filters-toolbar.bulk-actions, form#bulk-actions-toolbar-top' ).submit();
 				}
 
-				updateData.locale_slug = $gp_update_feedback_settings.locale_slug;
-				updateData.reason = updateReason;
-				updateData.comment = comment;
-				updateData.original_id = originalIds;
-				updateData.translation_id = translationIds;
-				updateData.is_bulk_reject = true;
-				updateWithFeedback( updateData, false, 'rejected' );
+				commentData.locale_slug = $gp_comment_feedback_settings.locale_slug;
+				commentData.reason = commentReason;
+				commentData.comment = comment;
+				commentData.original_id = originalIds;
+				commentData.translation_id = translationIds;
+				commentData.is_bulk_reject = true;
+				commentWithFeedback( commentData, false, 'rejected' );
 				e.preventDefault();
 			} );
 
@@ -105,33 +105,33 @@
 	function setStatus( that, status ) {
 		var button = $( that );
 		var feedbackData = {};
-		var updateReason = [];
+		var commentReason = [];
 		var comment = '';
 		var div = button.closest( 'div.meta' );
 
 		div.find( 'input[name="feedback_reason"]:checked' ).each(
 			function() {
-				updateReason.push( this.value );
+				commentReason.push( this.value );
 			}
 		);
 
 		comment = div.find( 'textarea[name="feedback_comment"]' ).val();
 
-		if ( ! comment.trim().length && ! updateReason.length ) {
+		if ( ! comment.trim().length && ! commentReason.length ) {
 			$gp.editor.set_status( button, status );
 			return;
 		}
 
-		feedbackData.locale_slug = $gp_update_feedback_settings.locale_slug;
-		feedbackData.reason = updateReason;
+		feedbackData.locale_slug = $gp_comment_feedback_settings.locale_slug;
+		feedbackData.reason = commentReason;
 		feedbackData.comment = comment;
 		feedbackData.original_id = [ $gp.editor.current.original_id ];
 		feedbackData.translation_id = [ $gp.editor.current.translation_id ];
 
-		updateWithFeedback( feedbackData, button, status );
+		commentWithFeedback( feedbackData, button, status );
 	}
 
-	function updateWithFeedback( feedbackData, button, status ) {
+	function commentWithFeedback( feedbackData, button, status ) {
 		var data = {};
 		var div = {};
 		if ( button ) {
@@ -139,17 +139,17 @@
 		}
 
 		data = {
-			action: 'update_with_feedback',
+			action: 'comment_with_feedback',
 			data: feedbackData,
 
-			_ajax_nonce: $gp_update_feedback_settings.nonce,
+			_ajax_nonce: $gp_comment_feedback_settings.nonce,
 		};
 
 		$.ajax(
 			{
 				type: 'POST',
 
-				url: $gp_update_feedback_settings.url,
+				url: $gp_comment_feedback_settings.url,
 				data: data,
 			}
 		).done(
@@ -175,20 +175,20 @@
 	}
 
 	function getReasonList( ) {
-		var updateReasons = $gp_update_feedback_settings.update_reasons;
-		var updateList = '';
+		var commentReasons = $gp_comment_feedback_settings.comment_reasons;
+		var commentList = '';
 		var prefix = '';
 		var suffix = '';
 		var inputName = '';
 
 		// eslint-disable-next-line vars-on-top
-		for ( var reason in updateReasons ) {
-			prefix = '<div class="modal-item"><label class="tooltip" title="' + updateReasons[ reason ].explanation + '">';
-			suffix = '</label> <span class="tooltip dashicons dashicons-info" title="' + updateReasons[ reason ].explanation + '"></span></div>';
+		for ( var reason in commentReasons ) {
+			prefix = '<div class="modal-item"><label class="tooltip" title="' + commentReasons[ reason ].explanation + '">';
+			suffix = '</label> <span class="tooltip dashicons dashicons-info" title="' + commentReasons[ reason ].explanation + '"></span></div>';
 			inputName = 'modal_feedback_reason';
-			updateList += prefix + '<input type="checkbox" name="' + inputName + '" value="' + reason + '" /> ' + updateReasons[ reason ].name + suffix;
+			commentList += prefix + '<input type="checkbox" name="' + inputName + '" value="' + reason + '" /> ' + commentReasons[ reason ].name + suffix;
 		}
-		return updateList;
+		return commentList;
 	}
 }( jQuery, $gp )
 );

--- a/templates/translation-row-editor-meta-feedback.php
+++ b/templates/translation-row-editor-meta-feedback.php
@@ -8,8 +8,8 @@
 			<h3 class="feedback-reason-title">Reason</h3>
 			<ul class="feedback-reason-list">
 			<?php
-				$update_reasons = Helper_Translation_Discussion::get_update_reasons();
-			foreach ( $update_reasons as $key => $reason ) :
+				$comment_reasons = Helper_Translation_Discussion::get_comment_reasons();
+			foreach ( $comment_reasons as $key => $reason ) :
 				?>
 					<li>
 						<label class="tooltip" title="<?php echo esc_attr( $reason['explanation'], 'glotpress' ); ?>"><input type="checkbox" name="feedback_reason" value="<?php echo esc_attr( $key, 'glotpress' ); ?>" /><?php echo esc_html( $reason['name'], 'glotpress' ); ?></label><span class="tooltip dashicons dashicons-info" title="<?php echo esc_attr( $reason['explanation'], 'glotpress' ); ?>"></span>

--- a/templates/translation-row-editor-meta-feedback.php
+++ b/templates/translation-row-editor-meta-feedback.php
@@ -8,8 +8,8 @@
 			<h3 class="feedback-reason-title">Reason</h3>
 			<ul class="feedback-reason-list">
 			<?php
-				$reject_reasons = Helper_Translation_Discussion::get_reject_reasons();
-			foreach ( $reject_reasons as $key => $reason ) :
+				$update_reasons = Helper_Translation_Discussion::get_update_reasons();
+			foreach ( $update_reasons as $key => $reason ) :
 				?>
 					<li>
 						<label class="tooltip" title="<?php echo esc_attr( $reason['explanation'], 'glotpress' ); ?>"><input type="checkbox" name="feedback_reason" value="<?php echo esc_attr( $key, 'glotpress' ); ?>" /><?php echo esc_html( $reason['name'], 'glotpress' ); ?></label><span class="tooltip dashicons dashicons-info" title="<?php echo esc_attr( $reason['explanation'], 'glotpress' ); ?>"></span>


### PR DESCRIPTION
## Problem

When you add some comments in a single action, if you approve or fuzzy the translation(s), the comment is not stored in the database, and we don't send any notifications.

See https://github.com/GlotPress/gp-translation-helpers/issues/91.

![image](https://user-images.githubusercontent.com/1667814/181226618-9a308464-364a-4345-83c5-262a1ed99cf9.png)

![image](https://user-images.githubusercontent.com/1667814/181226983-48ff996b-a83b-427b-b2be-0df5e3f50551.png)

We don't need to update the email template:

![image](https://user-images.githubusercontent.com/1667814/181227151-aeac10e3-d184-46bc-8037-0d2433025a64.png)

<!--
Please describe what is the status/problem before the PR.
-->

## Solution

We need to:
* Store the comment when the translation is set to approved or fuzzy.
* Update the template discussion, removing some references to "reject" or "rejection", because the comment can be related with other translation state.
* Send the notification to the translator.

This PR doesn't update the bulk rejection, so the users only can make comments in the bulk rejection, not in the bulk approve or bulk fuzzy.

Updates in the discussion template:

![image](https://user-images.githubusercontent.com/1667814/181284108-f760afb1-5510-4b28-850a-52d07fceb189.png)

<!--
Please describe how this PR improves the situation.
-->

## Testing instructions

* Make some comment in a pending translation.
* Set as approved or fuzzy.
* Go to the discussion page to see the comment.
* Check that the translator has received the email notification.
* Test that the bulk rejection is working fine.
<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

