### PR TITLE
Add link to specific comment on the discussions page

### DIFF
--- a/includes/class-gp-notifications.php
+++ b/includes/class-gp-notifications.php
@@ -386,7 +386,7 @@ class GP_Notifications {
 		$link_to_comment = $url . '#comment-' . $comment->comment_ID;
 		$output         .= wp_kses(
 			/* translators: The discussion URL where the user can find the comment. */
-			sprintf( __( 'There is a new <a href="%1$s">comment</a> in a <a href="%2$s">GlotPress discussion</a> that may be of interest to you.', 'glotpress' ), $link_to_comment, $url ),
+			sprintf( __( 'There is a <a href="%1$s">new comment</a> in a <a href="%2$s">GlotPress discussion</a> that may be of interest to you.', 'glotpress' ), $link_to_comment, $url ),
 			array(
 				'a' => array( 'href' => array() ),
 			)

--- a/includes/class-gp-notifications.php
+++ b/includes/class-gp-notifications.php
@@ -379,13 +379,14 @@ class GP_Notifications {
 		 * @param WP_Comment $comment      The comment object.
 		 * @param array      $comment_meta The meta values for the comment.
 		 */
-		$output  = apply_filters( 'gp_notification_pre_email_body', $output, $comment, $comment_meta );
-		$output .= esc_html__( 'Hi there,', 'glotpress' );
-		$output .= '<br><br>';
-		$url     = GP_Route_Translation_Helpers::get_permalink( $project->path, $original->id );
-		$output .= wp_kses(
+		$output          = apply_filters( 'gp_notification_pre_email_body', $output, $comment, $comment_meta );
+		$output         .= esc_html__( 'Hi there,', 'glotpress' );
+		$output         .= '<br><br>';
+		$url             = GP_Route_Translation_Helpers::get_permalink( $project->path, $original->id );
+		$link_to_comment = $url . '#comment-' . $comment->comment_ID;
+		$output         .= wp_kses(
 			/* translators: The discussion URL where the user can find the comment. */
-			sprintf( __( 'There is a new comment in a <a href="%1$s">GlotPress discussion</a> that may be of interest to you.', 'glotpress' ), $url ),
+			sprintf( __( 'There is a new <a href="%1$s">comment</a> in a <a href="%2$s">GlotPress discussion</a> that may be of interest to you.', 'glotpress' ), $link_to_comment, $url ),
 			array(
 				'a' => array( 'href' => array() ),
 			)

--- a/includes/class-gp-notifications.php
+++ b/includes/class-gp-notifications.php
@@ -386,7 +386,7 @@ class GP_Notifications {
 		$output .= '<br><br>';
 		$output .= wp_kses(
 			/* translators: The discussion URL where the user can find the comment. */
-			sprintf( __( 'There is a <a href="%1$s">new comment</a> in a <a href="%2$s">GlotPress discussion</a> that may be of interest to you.', 'glotpress' ), $link_to_comment, $url ),
+			sprintf( __( 'There is a <a href="%1$s">new comment in a GlotPress discussion</a> that may be of interest to you.', 'glotpress' ), $link_to_comment ),
 			array(
 				'a' => array( 'href' => array() ),
 			)

--- a/includes/class-gp-notifications.php
+++ b/includes/class-gp-notifications.php
@@ -366,10 +366,12 @@ class GP_Notifications {
 	 * @return string|null
 	 */
 	public static function get_email_body( WP_Comment $comment, array $comment_meta ): string {
-		$post     = get_post( $comment->comment_post_ID );
-		$project  = self::get_project_from_post( $post );
-		$original = self::get_original( $comment );
-		$output   = '';
+		$post            = get_post( $comment->comment_post_ID );
+		$project         = self::get_project_from_post( $post );
+		$original        = self::get_original( $comment );
+		$url             = GP_Route_Translation_Helpers::get_permalink( $project->path, $original->id );
+		$link_to_comment = $url . '#comment-' . $comment->comment_ID;
+		$output          = '';
 		/**
 		 * Filters the content of the email at the beginning of the function that gets its content.
 		 *
@@ -379,12 +381,10 @@ class GP_Notifications {
 		 * @param WP_Comment $comment      The comment object.
 		 * @param array      $comment_meta The meta values for the comment.
 		 */
-		$output          = apply_filters( 'gp_notification_pre_email_body', $output, $comment, $comment_meta );
-		$output         .= esc_html__( 'Hi there,', 'glotpress' );
-		$output         .= '<br><br>';
-		$url             = GP_Route_Translation_Helpers::get_permalink( $project->path, $original->id );
-		$link_to_comment = $url . '#comment-' . $comment->comment_ID;
-		$output         .= wp_kses(
+		$output  = apply_filters( 'gp_notification_pre_email_body', $output, $comment, $comment_meta );
+		$output .= esc_html__( 'Hi there,', 'glotpress' );
+		$output .= '<br><br>';
+		$output .= wp_kses(
 			/* translators: The discussion URL where the user can find the comment. */
 			sprintf( __( 'There is a <a href="%1$s">new comment</a> in a <a href="%2$s">GlotPress discussion</a> that may be of interest to you.', 'glotpress' ), $link_to_comment, $url ),
 			array(

--- a/includes/class-wporg-notifications.php
+++ b/includes/class-wporg-notifications.php
@@ -299,7 +299,7 @@ class WPorg_GlotPress_Notifications {
 	public static function get_email_body( WP_Comment $comment, ?array $comment_meta ): ?string {
 		$project         = self::get_project_from_post_id( $comment->comment_post_ID );
 		$original        = self::get_original( $comment->comment_post_ID );
-		$url             = GP_Route_Translation_Helpers::get_permalink( $project->path, $original->id ) . '#comment-' . $comment->comment_ID;
+		$url             = GP_Route_Translation_Helpers::get_permalink( $project->path, $original->id );
 		$link_to_comment = $url . '#comment-' . $comment->comment_ID;
 		$output          = esc_html__( 'Hi:' );
 		$output         .= '<br><br>';

--- a/includes/class-wporg-notifications.php
+++ b/includes/class-wporg-notifications.php
@@ -297,16 +297,22 @@ class WPorg_GlotPress_Notifications {
 	 * @return string|null The email body message.
 	 */
 	public static function get_email_body( WP_Comment $comment, ?array $comment_meta ): ?string {
-		$project  = self::get_project_from_post_id( $comment->comment_post_ID );
-		$original = self::get_original( $comment->comment_post_ID );
-		$output   = esc_html__( 'Hi:' );
-		$output  .= '<br><br>';
-		$output  .= esc_html__( 'There is a new comment in a discussion of the WordPress translation system that may be of interest to you.' );
-		$output  .= '<br>';
-		$output  .= esc_html__( 'It would be nice if you have some time to review this comment and reply to it if needed.' );
-		$output  .= '<br><br>';
-		$url      = GP_Route_Translation_Helpers::get_permalink( $project->path, $original->id );
-		$output  .= '- <strong>' . esc_html__( 'Discussion URL: ' ) . '</strong><a href="' . $url . '">' . $url . '</a><br>';
+		$project         = self::get_project_from_post_id( $comment->comment_post_ID );
+		$original        = self::get_original( $comment->comment_post_ID );
+		$url             = GP_Route_Translation_Helpers::get_permalink( $project->path, $original->id ) . '#comment-' . $comment->comment_ID;
+		$link_to_comment = $url . '#comment-' . $comment->comment_ID;
+		$output          = esc_html__( 'Hi:' );
+		$output         .= '<br><br>';
+		$output         .= wp_kses(
+			/* translators: The comment URL where the user can find the comment. */
+			sprintf( __( 'There is a new <a href="%1$s">comment</a> in a discussion of the WordPress translation system that may be of interest to you.', 'glotpress' ), $link_to_comment ),
+			array(
+				'a' => array( 'href' => array() ),
+			)
+		) . '<br>';
+		$output .= esc_html__( 'It would be nice if you have some time to review this comment and reply to it if needed.' );
+		$output .= '<br><br>';
+		$output .= '- <strong>' . esc_html__( 'Discussion URL: ' ) . '</strong><a href="' . $url . '">' . $url . '</a><br>';
 		if ( array_key_exists( 'locale', $comment_meta ) && ( ! empty( $comment_meta['locale'][0] ) ) ) {
 			$output .= '- <strong>' . esc_html__( 'Locale: ' ) . '</strong>' . esc_html( $comment_meta['locale'][0] ) . '<br>';
 		}

--- a/includes/class-wporg-notifications.php
+++ b/includes/class-wporg-notifications.php
@@ -305,7 +305,7 @@ class WPorg_GlotPress_Notifications {
 		$output         .= '<br><br>';
 		$output         .= wp_kses(
 			/* translators: The comment URL where the user can find the comment. */
-			sprintf( __( 'There is a new <a href="%1$s">comment</a> in a discussion of the WordPress translation system that may be of interest to you.', 'glotpress' ), $link_to_comment ),
+			sprintf( __( 'There is a <a href="%1$s">new comment</a> in a discussion of the WordPress translation system that may be of interest to you.', 'glotpress' ), $link_to_comment ),
 			array(
 				'a' => array( 'href' => array() ),
 			)

--- a/includes/class-wporg-notifications.php
+++ b/includes/class-wporg-notifications.php
@@ -305,7 +305,7 @@ class WPorg_GlotPress_Notifications {
 		$output         .= '<br><br>';
 		$output         .= wp_kses(
 			/* translators: The comment URL where the user can find the comment. */
-			sprintf( __( 'There is a <a href="%1$s">new comment</a> in a discussion of the WordPress translation system that may be of interest to you.', 'glotpress' ), $link_to_comment ),
+			sprintf( __( 'There is a <a href="%1$s">new comment in a discussion</a> of the WordPress translation system that may be of interest to you.', 'glotpress' ), $link_to_comment ),
 			array(
 				'a' => array( 'href' => array() ),
 			)


### PR DESCRIPTION
#### Problem
We need to add a link to the exact comment in the discussions page.

#### Solution

Added anchor tags to the " new comment in a GlotPress discussion" text in the email body.

#### Testing instructions

On a local GlotPress installation, clicking `new comment in a GlotPress discussion` or `new comment in a discussion` on translate.wordpress.org as shown below should redirect to the exact comment on the discussions page.
#### Before

<img width="691" alt="Screenshot 2022-07-28 at 16 23 13" src="https://user-images.githubusercontent.com/2834132/181576246-32cd9c7d-0f0a-459b-aab3-7f2314b033cc.png">

#### After
<img width="634" alt="Screenshot 2022-07-28 at 16 23 58" src="https://user-images.githubusercontent.com/2834132/181576462-bd689499-1550-4b7c-a4a0-fcd49e07c582.png">





