### PR TITLE
Check if the comment textarea exists to avoid a JS error

### DIFF
--- a/js/reject-feedback.js
+++ b/js/reject-feedback.js
@@ -117,7 +117,7 @@
 
 		comment = div.find( 'textarea[name="feedback_comment"]' ).val();
 
-		if ( comment === undefined || ( ! comment.trim().length && ! commentReason.length ) ) {
+		if ( ( comment === undefined && ! commentReason.length ) || ( ! comment.trim().length && ! commentReason.length ) ) {
 			$gp.editor.set_status( button, status );
 			return;
 		}

--- a/js/reject-feedback.js
+++ b/js/reject-feedback.js
@@ -117,7 +117,7 @@
 
 		comment = div.find( 'textarea[name="feedback_comment"]' ).val();
 
-		if ( ! comment.trim().length && ! commentReason.length ) {
+		if ( ( comment === undefined ) || ( ! comment.trim().length && ! commentReason.length ) ) {
 			$gp.editor.set_status( button, status );
 			return;
 		}

--- a/js/reject-feedback.js
+++ b/js/reject-feedback.js
@@ -117,7 +117,7 @@
 
 		comment = div.find( 'textarea[name="feedback_comment"]' ).val();
 
-		if ( ( comment === undefined ) || ( ! comment.trim().length && ! commentReason.length ) ) {
+		if ( comment === undefined || ( ! comment.trim().length && ! commentReason.length ) ) {
 			$gp.editor.set_status( button, status );
 			return;
 		}


### PR DESCRIPTION
## Problem

We have a JS problem when a translator suggests a translation, and then she tries to reject her own translation. See https://github.com/GlotPress/gp-translation-helpers/issues/98.

<!--
Please describe what is the status/problem before the PR.
-->

## Solution

This solution checks if a textarea is defined, to avoid errors when we try to access to an undefined object.

<!--
Please describe how this PR improves the situation.
-->

## Testing instructions

1. Log in with a non validator user.
2. Suggest a string.
3. Reject your own suggestion.
4. You get the string rejected. Before this PR, in this step, you get an error.

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

