### PR TITLE
Add the plugin version in the asset register: CSS and JS

### DIFF
--- a/gp-translation-helpers.php
+++ b/gp-translation-helpers.php
@@ -7,7 +7,7 @@
  * Plugin name:     GP Translation Helpers
  * Plugin URI:      https://github.com/GlotPress/gp-translation-helpers
  * Description:     GlotPress plugin to discuss the strings that are being translated in GlotPress.
- * Version:         0.0.2
+ * Version:         0.0.3
  * Requires PHP:    7.4
  * Author:          the GlotPress team
  * Author URI:      https://glotpress.blog

--- a/includes/class-gp-translation-helpers.php
+++ b/includes/class-gp-translation-helpers.php
@@ -32,6 +32,14 @@ class GP_Translation_Helpers {
 	private static $instance = null;
 
 	/**
+	 * Stores plugin version.
+	 *
+	 * @since 0.0.2
+	 * @var string
+	 */
+	private static $plugin_version = null;
+
+	/**
 	 * Inits the class.
 	 *
 	 * @since 0.0.1
@@ -64,10 +72,15 @@ class GP_Translation_Helpers {
 		add_action( 'wp_ajax_comment_with_feedback', array( $this, 'comment_with_feedback' ) );
 		add_action( 'wp_ajax_optout_discussion_notifications', array( $this, 'optout_discussion_notifications' ) );
 
+		if ( ! function_exists( 'get_plugins' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/plugin.php';
+		}
+		self::$plugin_version = get_plugins()['gp-translation-helpers/gp-translation-helpers.php']['Version'];
+
 		add_thickbox();
 		gp_enqueue_style( 'thickbox' );
 
-		wp_register_style( 'gp-discussion-css', plugins_url( '/../css/discussion.css', __FILE__ ), array(), '20220801' );
+		wp_register_style( 'gp-discussion-css', plugins_url( '/../css/discussion.css', __FILE__ ), array(), self::$plugin_version );
 		gp_enqueue_style( 'gp-discussion-css' );
 
 		add_filter( 'gp_translation_row_template_more_links', array( $this, 'translation_row_template_more_links' ), 10, 5 );
@@ -189,10 +202,10 @@ class GP_Translation_Helpers {
 			}
 		);
 
-		wp_register_style( 'gp-translation-helpers-css', plugins_url( 'css/translation-helpers.css', __DIR__ ), '', '20220801' ); // todo: add the version as global element.
+		wp_register_style( 'gp-translation-helpers-css', plugins_url( 'css/translation-helpers.css', __DIR__ ), '', self::$plugin_version );
 		gp_enqueue_style( 'gp-translation-helpers-css' );
 
-		wp_register_script( 'gp-translation-helpers', plugins_url( '/js/translation-helpers.js', __DIR__ ), array( 'gp-editor' ), '20220801', true );
+		wp_register_script( 'gp-translation-helpers', plugins_url( '/js/translation-helpers.js', __DIR__ ), array( 'gp-editor' ), self::$plugin_version, true );
 		gp_enqueue_scripts( array( 'gp-translation-helpers' ) );
 
 		wp_localize_script( 'gp-translation-helpers', '$gp_translation_helpers_settings', $translation_helpers_settings );
@@ -363,7 +376,7 @@ class GP_Translation_Helpers {
 			return;
 		}
 
-		wp_register_script( 'gp-comment-feedback-js', plugins_url( '/../js/reject-feedback.js', __FILE__ ), array( 'jquery', 'gp-common', 'gp-editor', 'thickbox' ), '20220801' );
+		wp_register_script( 'gp-comment-feedback-js', plugins_url( '/../js/reject-feedback.js', __FILE__ ), array( 'jquery', 'gp-common', 'gp-editor', 'thickbox' ), self::$plugin_version );
 		gp_enqueue_script( 'gp-comment-feedback-js' );
 
 		wp_localize_script(

--- a/includes/class-gp-translation-helpers.php
+++ b/includes/class-gp-translation-helpers.php
@@ -32,14 +32,6 @@ class GP_Translation_Helpers {
 	private static $instance = null;
 
 	/**
-	 * Stores plugin version.
-	 *
-	 * @since 0.0.2
-	 * @var string
-	 */
-	private static $plugin_version = null;
-
-	/**
 	 * Inits the class.
 	 *
 	 * @since 0.0.1
@@ -72,15 +64,15 @@ class GP_Translation_Helpers {
 		add_action( 'wp_ajax_comment_with_feedback', array( $this, 'comment_with_feedback' ) );
 		add_action( 'wp_ajax_optout_discussion_notifications', array( $this, 'optout_discussion_notifications' ) );
 
-		if ( ! function_exists( 'get_plugins' ) ) {
-			require_once ABSPATH . 'wp-admin/includes/plugin.php';
-		}
-		self::$plugin_version = get_plugins()['gp-translation-helpers/gp-translation-helpers.php']['Version'];
-
 		add_thickbox();
 		gp_enqueue_style( 'thickbox' );
 
-		wp_register_style( 'gp-discussion-css', plugins_url( '/../css/discussion.css', __FILE__ ), array(), self::$plugin_version );
+		wp_register_style(
+			'gp-discussion-css',
+			plugins_url( 'css/discussion.css', __DIR__ ),
+			array(),
+			filemtime( plugin_dir_path( __DIR__ ) . 'css/discussion.css' )
+		);
 		gp_enqueue_style( 'gp-discussion-css' );
 
 		add_filter( 'gp_translation_row_template_more_links', array( $this, 'translation_row_template_more_links' ), 10, 5 );
@@ -202,10 +194,21 @@ class GP_Translation_Helpers {
 			}
 		);
 
-		wp_register_style( 'gp-translation-helpers-css', plugins_url( 'css/translation-helpers.css', __DIR__ ), '', self::$plugin_version );
+		wp_register_style(
+			'gp-translation-helpers-css',
+			plugins_url( 'css/translation-helpers.css', __DIR__ ),
+			array(),
+			filemtime( plugin_dir_path( __DIR__ ) . 'css/translation-helpers.css' )
+		);
 		gp_enqueue_style( 'gp-translation-helpers-css' );
 
-		wp_register_script( 'gp-translation-helpers', plugins_url( '/js/translation-helpers.js', __DIR__ ), array( 'gp-editor' ), self::$plugin_version, true );
+		wp_register_script(
+			'gp-translation-helpers',
+			plugins_url( 'js/translation-helpers.js', __DIR__ ),
+			array( 'gp-editor' ),
+			filemtime( plugin_dir_path( __DIR__ ) . 'js/translation-helpers.js' ),
+			true
+		);
 		gp_enqueue_scripts( array( 'gp-translation-helpers' ) );
 
 		wp_localize_script( 'gp-translation-helpers', '$gp_translation_helpers_settings', $translation_helpers_settings );
@@ -376,7 +379,12 @@ class GP_Translation_Helpers {
 			return;
 		}
 
-		wp_register_script( 'gp-comment-feedback-js', plugins_url( '/../js/reject-feedback.js', __FILE__ ), array( 'jquery', 'gp-common', 'gp-editor', 'thickbox' ), self::$plugin_version );
+		wp_register_script(
+			'gp-comment-feedback-js',
+			plugins_url( 'js/reject-feedback.js', __DIR__ ),
+			array( 'jquery', 'gp-common', 'gp-editor', 'thickbox' ),
+			filemtime( plugin_dir_path( __DIR__ ) . 'js/reject-feedback.js' )
+		);
 		gp_enqueue_script( 'gp-comment-feedback-js' );
 
 		wp_localize_script(


### PR DESCRIPTION
## Problem

Sometimes when we deploy the plugin to DotOrg, we have problems with the asset versions (CSS and JS), so we need to set a method to version and update the assets each time we deploy to production.

<!--
Please describe what is the status/problem before the PR.
-->

## Solution

Use the plugin version as asset version. Using this value (and increasing it each time we deploy at DotOrg) we will avoid version problems with the assets.

<!--
Please describe how this PR improves the situation.
-->

#### Testing instructions

Load a translation page or a discussion page (in a local GlotPress or at DotOrg) and you will see that the plugin assets (CSS and JS) will have the plugin version as version number (0.0.3 in this example):

`<link rel="stylesheet" id="gp-discussion-css-css" href="https://glotpress.test/wp-content/plugins/gp-translation-helpers/includes/../css/discussion.css?ver=0.0.3" media="all">`

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

