### PR TITLE
Add the status of the translation in the discussion

### DIFF
--- a/helpers-assets/templates/translation-discussion-comments.php
+++ b/helpers-assets/templates/translation-discussion-comments.php
@@ -144,7 +144,7 @@
 					array(
 						'<input type="hidden" name="comment_locale" value="' . esc_attr( $locale_slug ) . '" />',
 						'<input type="hidden" name="translation_id" value="' . esc_attr( $translation_id ) . '" />',
-						'<input type="hidden" name="redirect_to" value="ddd' . esc_url( $original_permalink ) . '" />',
+						'<input type="hidden" name="redirect_to" value="' . esc_url( $original_permalink ) . '" />',
 					)
 				),
 			),

--- a/helpers-assets/templates/translation-discussion-comments.php
+++ b/helpers-assets/templates/translation-discussion-comments.php
@@ -144,7 +144,8 @@
 					array(
 						'<input type="hidden" name="comment_locale" value="' . esc_attr( $locale_slug ) . '" />',
 						'<input type="hidden" name="translation_id" value="' . esc_attr( $translation_id ) . '" />',
-						'<input type="hidden" name="redirect_to" value="' . esc_url( $original_permalink ) . '" />',
+						'<input type="hidden" name="translation_status" value="' . esc_attr( $displayed_translation_status ) . '" />',
+						'<input type="hidden" name="redirect_to" value="ddd' . esc_url( $original_permalink ) . '" />',
 					)
 				),
 			),
@@ -167,6 +168,5 @@
 		/* translators: Log in URL. */
 		echo sprintf( __( 'You have to be <a href="%s">logged in</a> to comment.' ), esc_html( wp_login_url() ) );
 	}
-
 	?>
 </div><!-- .discussion-wrapper -->

--- a/helpers-assets/templates/translation-discussion-comments.php
+++ b/helpers-assets/templates/translation-discussion-comments.php
@@ -144,7 +144,6 @@
 					array(
 						'<input type="hidden" name="comment_locale" value="' . esc_attr( $locale_slug ) . '" />',
 						'<input type="hidden" name="translation_id" value="' . esc_attr( $translation_id ) . '" />',
-						'<input type="hidden" name="translation_status" value="' . esc_attr( $displayed_translation_status ) . '" />',
 						'<input type="hidden" name="redirect_to" value="ddd' . esc_url( $original_permalink ) . '" />',
 					)
 				),

--- a/helpers/helper-translation-discussion.php
+++ b/helpers/helper-translation-discussion.php
@@ -690,7 +690,7 @@ class Helper_Translation_Discussion extends GP_Translation_Helper {
 	 * @return string
 	 */
 	public function sanitize_translation_status( string $translation_status ): string {
-		if ( ! in_array( $translation_status, array( 'approved', 'rejected', 'waiting', 'current', 'fuzzy' ), true ) ) {
+		if ( ! in_array( $translation_status, array( 'approved', 'rejected', 'waiting', 'current', 'fuzzy', 'changesrequested' ), true ) ) {
 			$translation_status = 'unknown';
 		}
 		return $translation_status;

--- a/helpers/helper-translation-discussion.php
+++ b/helpers/helper-translation-discussion.php
@@ -533,16 +533,14 @@ class Helper_Translation_Discussion extends GP_Translation_Helper {
 		$output = gp_tmpl_get_output(
 			'translation-discussion-comments',
 			array(
-				'comments'                     => $comments,
-				'post'                         => $post,
-				'translation_id'               => isset( $this->data['translation_id'] ) ? $this->data['translation_id'] : null,
-				'locale_slug'                  => $this->data['locale_slug'],
-				'original_permalink'           => $this->data['original_permalink'],
-				'original_id'                  => $this->data['original_id'],
-				'project'                      => $this->data['project'],
-				'translation_set_slug'         => $this->data['translation_set_slug'],
-				'displayed_translation_status' => $this->data['displayed_translation_status'],
-
+				'comments'             => $comments,
+				'post'                 => $post,
+				'translation_id'       => isset( $this->data['translation_id'] ) ? $this->data['translation_id'] : null,
+				'locale_slug'          => $this->data['locale_slug'],
+				'original_permalink'   => $this->data['original_permalink'],
+				'original_id'          => $this->data['original_id'],
+				'project'              => $this->data['project'],
+				'translation_set_slug' => $this->data['translation_set_slug'],
 			),
 			$this->assets_dir . 'templates'
 		);
@@ -857,7 +855,7 @@ function gth_discussion_callback( WP_Comment $comment, array $args, int $depth )
 
 	$comment_reason = get_comment_meta( $comment->comment_ID, 'reject_reason', true );
 
-	$comment_trans_status = get_comment_meta( $comment->comment_ID, 'translation_status', true );
+	$_translation_status = get_comment_meta( $comment->comment_ID, 'translation_status', true );
 
 	$classes = array( 'comment-locale-' . $comment_locale );
 	if ( ! empty( $comment_reason ) ) {
@@ -990,11 +988,11 @@ function gth_discussion_callback( WP_Comment $comment, array $args, int $depth )
 
 			if ( ! $is_linking_comment ) :
 				if ( $comment_translation_id && $comment_translation_id !== $current_translation_id ) {
-					$translation_status = GP::$translation->get( $comment_translation_id )->status;
-					if ( $translation_status ) {
-						$translation_status = ' (' . $translation_status . ')';
+					$translation_status = '';
+					if ( $_translation_status ) {
+						$translation_status = ' (' . $_translation_status . ')';
 					}
-					gth_print_translation( $comment_translation_id, $args, 'Translation' . $translation_status . ':' );
+					gth_print_translation( $comment_translation_id, $args, 'Translation' . $translation_status . ': ' );
 				}
 
 				?>

--- a/helpers/helper-translation-discussion.php
+++ b/helpers/helper-translation-discussion.php
@@ -956,7 +956,11 @@ function gth_discussion_callback( WP_Comment $comment, array $args, int $depth )
 
 			if ( ! $is_linking_comment ) :
 				if ( $comment_translation_id && $comment_translation_id !== $current_translation_id ) {
-					gth_print_translation( $comment_translation_id, $args, 'Translation: ' );
+					$translation_status = GP::$translation->get( $comment_translation_id )->status;
+					if ( $translation_status ) {
+						$translation_status = ' (' . $translation_status . ')';
+					}
+					gth_print_translation( $comment_translation_id, $args, 'Translation' . $translation_status . ':' );
 				}
 
 				?>

--- a/includes/class-gp-route-translation-helpers.php
+++ b/includes/class-gp-route-translation-helpers.php
@@ -123,7 +123,15 @@ class GP_Route_Translation_Helpers extends GP_Route {
 		$priorities_key_value = $original->get_static( 'priorities' );
 		$priority             = $priorities_key_value[ $original->priority ];
 
-		$args     = compact( 'project', 'locale_slug', 'translation_set_slug', 'original_id', 'translation_id', 'translation', 'original_permalink' );
+		/** Get recent translation status */
+		$displayed_translation_status = '';
+		if ( $translation ) {
+			$displayed_translation_status = $translation->status;
+		} elseif ( $existing_translations ) {
+			$displayed_translation_status = $existing_translations[0]->status;
+		}
+
+		$args     = compact( 'project', 'locale_slug', 'translation_set_slug', 'original_id', 'translation_id', 'translation', 'original_permalink', 'displayed_translation_status' );
 		$sections = $this->get_translation_helper_sections( $args );
 
 		$translations       = GP::$translation->find_many_no_map(

--- a/includes/class-gp-route-translation-helpers.php
+++ b/includes/class-gp-route-translation-helpers.php
@@ -123,14 +123,6 @@ class GP_Route_Translation_Helpers extends GP_Route {
 		$priorities_key_value = $original->get_static( 'priorities' );
 		$priority             = $priorities_key_value[ $original->priority ];
 
-		/** Get recent translation status */
-		$displayed_translation_status = '';
-		if ( $translation ) {
-			$displayed_translation_status = $translation->status;
-		} elseif ( $existing_translations ) {
-			$displayed_translation_status = $existing_translations[0]->status;
-		}
-
 		$args     = compact( 'project', 'locale_slug', 'translation_set_slug', 'original_id', 'translation_id', 'translation', 'original_permalink', 'displayed_translation_status' );
 		$sections = $this->get_translation_helper_sections( $args );
 

--- a/includes/class-gp-route-translation-helpers.php
+++ b/includes/class-gp-route-translation-helpers.php
@@ -123,7 +123,7 @@ class GP_Route_Translation_Helpers extends GP_Route {
 		$priorities_key_value = $original->get_static( 'priorities' );
 		$priority             = $priorities_key_value[ $original->priority ];
 
-		$args     = compact( 'project', 'locale_slug', 'translation_set_slug', 'original_id', 'translation_id', 'translation', 'original_permalink', 'displayed_translation_status' );
+		$args     = compact( 'project', 'locale_slug', 'translation_set_slug', 'original_id', 'translation_id', 'translation', 'original_permalink' );
 		$sections = $this->get_translation_helper_sections( $args );
 
 		$translations       = GP::$translation->find_many_no_map(

--- a/includes/class-gp-translation-helpers.php
+++ b/includes/class-gp-translation-helpers.php
@@ -390,6 +390,7 @@ class GP_Translation_Helpers {
 
 		$helper_discussion    = new Helper_Translation_Discussion();
 		$locale_slug          = $helper_discussion->sanitize_comment_locale( sanitize_text_field( $_POST['data']['locale_slug'] ) );
+		$translation_status   = $helper_discussion->sanitize_translation_status( sanitize_text_field( $_POST['data']['translation_status'] ) );
 		$translation_id_array = ! empty( $_POST['data']['translation_id'] ) ? array_map( array( $helper_discussion, 'sanitize_translation_id' ), $_POST['data']['translation_id'] ) : null;
 		$original_id_array    = ! empty( $_POST['data']['original_id'] ) ? array_map( array( $helper_discussion, 'sanitize_original_id' ), $_POST['data']['original_id'] ) : null;
 		$comment_reason       = ! empty( $_POST['data']['reason'] ) ? $_POST['data']['reason'] : array( 'other' );
@@ -411,13 +412,13 @@ class GP_Translation_Helpers {
 		$first_translation_id = array_shift( $translation_id_array );
 
 		// Post comment on discussion page for the first string
-		$first_comment_id = $this->insert_comment( $comment, $first_original_id, $comment_reason, $first_translation_id, $locale_slug, $_SERVER );
+		$first_comment_id = $this->insert_comment( $comment, $first_original_id, $comment_reason, $first_translation_id, $locale_slug, $_SERVER, $translation_status );
 
 		if ( ! empty( $original_id_array ) && ! empty( $translation_id_array ) ) {
 			// For other strings post link to the comment.
 			$comment = get_comment_link( $first_comment_id );
 			foreach ( $original_id_array as $index => $single_original_id ) {
-				$comment_id = $this->insert_comment( $comment, $single_original_id, $comment_reason, $translation_id_array[ $index ], $locale_slug, $_SERVER );
+				$comment_id = $this->insert_comment( $comment, $single_original_id, $comment_reason, $translation_id_array[ $index ], $locale_slug, $_SERVER, $translation_status );
 				$comment    = get_comment( $comment_id );
 				GP_Notifications::add_related_comment( $comment );
 			}
@@ -475,7 +476,7 @@ class GP_Translation_Helpers {
 	 * @return false|int
 	 * @since 0.0.2
 	 */
-	private function insert_comment( $comment, $original_id, $reason, $translation_id, $locale_slug, $server ) {
+	private function insert_comment( $comment, $original_id, $reason, $translation_id, $locale_slug, $server, $translation_status ) {
 		$post_id = Helper_Translation_Discussion::get_or_create_shadow_post_id( $original_id );
 		$user    = wp_get_current_user();
 		return wp_insert_comment(
@@ -489,9 +490,10 @@ class GP_Translation_Helpers {
 				'comment_agent'        => sanitize_text_field( $server['HTTP_USER_AGENT'] ),
 				'user_id'              => $user->ID,
 				'comment_meta'         => array(
-					'reject_reason'  => $reason,
-					'translation_id' => $translation_id,
-					'locale'         => $locale_slug,
+					'reject_reason'      => $reason,
+					'translation_id'     => $translation_id,
+					'locale'             => $locale_slug,
+					'translation_status' => $translation_status,
 				),
 			)
 		);

--- a/js/reject-feedback.js
+++ b/js/reject-feedback.js
@@ -127,6 +127,7 @@
 		feedbackData.comment = comment;
 		feedbackData.original_id = [ $gp.editor.current.original_id ];
 		feedbackData.translation_id = [ $gp.editor.current.translation_id ];
+		feedbackData.translation_status = status;
 
 		commentWithFeedback( feedbackData, button, status );
 	}


### PR DESCRIPTION
## Problem

When you are in the discussion page for an original, you don't get the translation status of the translation related with each comment. 

Fixes #103. 

![image](https://user-images.githubusercontent.com/1667814/182389972-420f4e0f-b9e4-4155-9bd9-c347b3f56896.png)

<!--
Please describe what is the status/problem before the PR.
-->

## Solution

This PR adds the translation status related with the comment.

![image](https://user-images.githubusercontent.com/1667814/182390801-7e31cf4e-bed3-4a5a-878d-56f0a7c1e0ff.png)

![image](https://user-images.githubusercontent.com/1667814/182391705-36b7a412-18fd-4dcf-8067-ca15eebece15.png)
<!--
Please describe how this PR improves the situation.
-->

## Testing instructions

For an original string:
* Suggest a translation.
* Reject this suggestion with comment.
* Suggest another different translation.
* Accept this suggestion with comment.
* Go to the discussion page for this original. You will see the translation status of the string related with the comment.

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

