### PR TITLE
is_global_optout_email_address parameter incorrect

### DIFF
--- a/includes/class-wporg-notifications.php
+++ b/includes/class-wporg-notifications.php
@@ -442,15 +442,12 @@ class WPorg_GlotPress_Notifications {
 	 *
 	 * @since 0.0.2
 	 *
-	 * @param ?string $email_address The user's email address.
+	 * @param string $email_address The user's email address.
 	 *
 	 * @return bool Whether a user wis globally opt-out.
 	 */
-	private static function is_global_optout_email_address( ?string $email_address ): bool {
-		if ( is_null( $email_address ) ) {
-			return false;
-		}
-		if ( ! is_email( $email_address ) ) {
+	private static function is_global_optout_email_address( string $email_address ): bool {
+		if ( empty( $email_address ) || ! is_email( $email_address ) ) {
 			return false;
 		}
 		$user            = get_user_by( 'email', $email_address );
@@ -605,8 +602,7 @@ class WPorg_GlotPress_Notifications {
 		$user = wp_get_current_user();
 
 		if ( ! $user->user_email ) {
-			$output = __( "You will not receive notifications because you don't have an e-mail address set." );
-			return $output;
+			return __( "You will not receive notifications because you don't have an e-mail address set." );
 		}
 		if ( self::is_global_optout_email_address( $user->user_email ) ) {
 			$output  = __( 'You will not receive notifications because you have not yet opted-in.' );

--- a/includes/class-wporg-notifications.php
+++ b/includes/class-wporg-notifications.php
@@ -430,7 +430,7 @@ class WPorg_GlotPress_Notifications {
 	 */
 	private static function get_opted_in_email_addresses( array $email_addresses ): array {
 		foreach ( $email_addresses as $index => $email_address ) {
-			if ( ! $email_address || self::is_global_optout_email_address( $email_address ) ) {
+			if ( ! is_string( $email_address ) || empty( $email_address ) || self::is_global_optout_email_address( $email_address ) ) {
 				unset( $email_addresses[ $index ] );
 			}
 		}

--- a/includes/class-wporg-notifications.php
+++ b/includes/class-wporg-notifications.php
@@ -445,11 +445,17 @@ class WPorg_GlotPress_Notifications {
 	 *
 	 * @since 0.0.2
 	 *
-	 * @param string $email_address The user's email address.
+	 * @param ?string $email_address The user's email address.
 	 *
 	 * @return bool Whether a user wis globally opt-out.
 	 */
-	private static function is_global_optout_email_address( string $email_address ): bool {
+	private static function is_global_optout_email_address( ?string $email_address ): bool {
+		if ( is_null( $email_address ) ) {
+			return false;
+		}
+		if ( ! is_email( $email_address ) ) {
+			return false;
+		}
 		$user            = get_user_by( 'email', $email_address );
 		$gp_default_sort = get_user_option( 'gp_default_sort', $user->ID );
 		if ( 'on' != gp_array_get( $gp_default_sort, 'notifications_optin', 'off' ) ) {

--- a/includes/class-wporg-notifications.php
+++ b/includes/class-wporg-notifications.php
@@ -429,12 +429,9 @@ class WPorg_GlotPress_Notifications {
 	 * @return array The list of emails with the opt-in enabled.
 	 */
 	private static function get_opted_in_email_addresses( array $email_addresses ): array {
-		foreach ( $email_addresses as $email_address ) {
-			if ( self::is_global_optout_email_address( $email_address ) ) {
-				$index = array_search( $email_address, $email_addresses, true );
-				if ( false !== $index ) {
-					unset( $email_addresses[ $index ] );
-				}
+		foreach ( $email_addresses as $index => $email_address ) {
+			if ( ! $email_address || self::is_global_optout_email_address( $email_address ) ) {
+				unset( $email_addresses[ $index ] );
 			}
 		}
 		return array_values( $email_addresses );
@@ -607,8 +604,12 @@ class WPorg_GlotPress_Notifications {
 	public static function optin_message_for_each_discussion( int $original_id ): string {
 		$user = wp_get_current_user();
 
+		if ( ! $user->user_email ) {
+			$output = __( "You will not receive notifications because you don't have an e-mail address set." );
+			return $output;
+		}
 		if ( self::is_global_optout_email_address( $user->user_email ) ) {
-			$output  = __( 'You will not receive notifications because you have not yet opted-in. ' );
+			$output  = __( 'You will not receive notifications because you have not yet opted-in.' );
 			$output .= ' <a href="https://translate.wordpress.org/settings/">' . __( 'Start receiving notifications.' ) . '</a>';
 			return $output;
 		}


### PR DESCRIPTION
## Problem

We have some errors with this message:

```
Uncaught TypeError: Argument 1 passed to WPorg_GlotPress_Notifications::is_global_optout_email_address() must be of the type string, null given, called in gp-translation-helpers/includes/class-wporg-notifications.php on line 427 
```

```
Uncaught TypeError: Argument 1 passed to WPorg_GlotPress_Notifications::is_global_optout_email_address() must be of the type string, null given, called in gp-translation-helpers/includes/class-wporg-notifications.php on line 433 and defined in gp-translation-helpers/includes/class-wporg-notifications.php:452
Stack trace:
#0 gp-translation-helpers/includes/class-wporg-notifications.php(433): WPorg_GlotPress_Notifications::is_global_optout_email_address(NULL)
#1 gp-translation-helpers/includes/class-wporg-notifications.php(75):
```


Fixes https://github.com/GlotPress/gp-translation-helpers/issues/94. 

<!--
Please describe what is the status/problem before the PR.
-->

## Solution

It looks like the `WPorg_GlotPress_Notifications::is_global_optout_email_address()` is called with a null parameter, so:
* We have to allow this type. 
* We have to check if the parameter is an email: is null or is not valid.

<!--
Please describe how this PR improves the situation.
-->

## Testing instructions

It is hard to check, because we have to update a correct email in the production database to a null value. It is better to check all is working fine and to review the logs, to see this error doesn't continue.
<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->