### PR TITLE
Fix discussion form not showing in empty discussions

### DIFF
--- a/helpers/helper-translation-discussion.php
+++ b/helpers/helper-translation-discussion.php
@@ -89,6 +89,7 @@ class Helper_Translation_Discussion extends GP_Translation_Helper {
 	public function after_constructor() {
 		$this->register_post_type_and_taxonomy();
 		add_filter( 'pre_comment_approved', array( $this, 'comment_moderation' ), 10, 2 );
+		add_filter( 'comments_open', array( $this, 'comments_open_override' ), 10, 2 );
 		add_filter( 'map_meta_cap', array( $this, 'map_comment_meta_caps' ), 10, 4 );
 		add_filter( 'user_has_cap', array( $this, 'give_user_read_cap' ), 10, 3 );
 		add_filter( 'post_type_link', array( $this, 'rewrite_original_post_type_permalink' ), 10, 2 );
@@ -249,6 +250,13 @@ class Helper_Translation_Discussion extends GP_Translation_Helper {
 		$cache[ $post->ID ] = GP_Route_Translation_Helpers::get_permalink( $project->path, $original_id );
 
 		return $cache[ $post->ID ];
+	}
+
+	public function comments_open_override( $open, $post_id ) {
+		if ( 0 === $post_id || self::is_temporary_post_id( $post_id ) ) {
+			return true;
+		}
+		return $open;
 	}
 
 	/**

--- a/includes/class-gth-temporary-post.php
+++ b/includes/class-gth-temporary-post.php
@@ -3,8 +3,6 @@
 class Gth_Temporary_Post {
 	public $ID;
 	public $comments_open = 'open';
-	public $comment_status = 'open';
-	public $filter = 'raw';
 	public function __construct( $post_id ) {
 		$this->ID = $post_id;
 	}

--- a/includes/class-gth-temporary-post.php
+++ b/includes/class-gth-temporary-post.php
@@ -3,6 +3,8 @@
 class Gth_Temporary_Post {
 	public $ID;
 	public $comments_open = 'open';
+	public $comment_status = 'open';
+	public $filter = 'raw';
 	public function __construct( $post_id ) {
 		$this->ID = $post_id;
 	}


### PR DESCRIPTION
#### Problem

On WordPress trunk our "hack" for displaying the comment form without an existing (shadow) post no longer works (broken by https://github.com/WordPress/WordPress/commit/1069ac4afda821742cf7f600412aacc139013a55). Thus no comment form is displayed if there is no other discussion. We also want to avoid creating shadow posts just by visiting the page, so that we don't end up with many posts without discussion.

#### Solution

This PR attempts to solve this although only haphazardly so far (by checking for `$post_id === 0`).

#### Testing instructions

Go to a discussion page of an original that doesn't have a discussion yet. The comment form should be visible.