### PR TITLE
Add rejection reasons to email body

### DIFF
--- a/includes/class-gp-notifications.php
+++ b/includes/class-gp-notifications.php
@@ -433,7 +433,7 @@ class GP_Notifications {
 				maybe_unserialize( $comment_meta['reject_reason'][0] )
 			);
 			/* translators: The reason(s) for rejection. */
-			$output .= '- ' . wp_kses( sprintf( __( '<strong>Reason:</strong> %s', 'glotpress' ), implode( ', ', $reasons ) ), array( 'strong' => array() ) ) . '<br/>';
+			$output .= '- ' . wp_kses( sprintf( __( '<strong>Reason(s):</strong> %s', 'glotpress' ), implode( ', ', $reasons ) ), array( 'strong' => array() ) ) . '<br/>';
 		}
 		/* translators: The comment made. */
 		$output .= '- ' . wp_kses( sprintf( __( '<strong>Comment:</strong> %s', 'glotpress' ), $comment->comment_content ), array( 'strong' => array() ) ) . '<br/>';

--- a/includes/class-gp-notifications.php
+++ b/includes/class-gp-notifications.php
@@ -421,6 +421,21 @@ class GP_Notifications {
 				}
 			}
 		}
+		if ( array_key_exists( 'reject_reason', $comment_meta ) && ( ! empty( $comment_meta['reject_reason'][0] ) ) ) {
+			/* translators: The reason(s) for rejection. */
+			$reasons         = array();
+			$comment_reasons = Helper_Translation_Discussion::get_comment_reasons();
+			$reasons         = array_map(
+				function( $reason ) use ( $comment_reasons ) {
+					if ( array_key_exists( $reason, $comment_reasons ) ) {
+						return $comment_reasons[ $reason ]['name'];
+					}
+				},
+				maybe_unserialize( $comment_meta['reject_reason'][0] )
+			);
+
+			$output .= '- ' . wp_kses( sprintf( __( '<strong>Reason:</strong> %s', 'glotpress' ), implode( ', ', $reasons ) ), array( 'strong' => array() ) ) . '<br/>';
+		}
 		/* translators: The comment made. */
 		$output .= '- ' . wp_kses( sprintf( __( '<strong>Comment:</strong> %s', 'glotpress' ), $comment->comment_content ), array( 'strong' => array() ) ) . '<br/>';
 		if ( empty( self::$related_comments ) ) {

--- a/includes/class-gp-notifications.php
+++ b/includes/class-gp-notifications.php
@@ -421,7 +421,7 @@ class GP_Notifications {
 				}
 			}
 		}
-		if ( array_key_exists( 'reject_reason', $comment_meta ) && ( ! empty( $comment_meta['reject_reason'][0] ) ) ) {
+		if ( ! empty( $comment_meta['reject_reason'][0] ) ) {
 			$reasons         = array();
 			$comment_reasons = Helper_Translation_Discussion::get_comment_reasons();
 			$reasons         = array_map(

--- a/includes/class-gp-notifications.php
+++ b/includes/class-gp-notifications.php
@@ -422,7 +422,6 @@ class GP_Notifications {
 			}
 		}
 		if ( array_key_exists( 'reject_reason', $comment_meta ) && ( ! empty( $comment_meta['reject_reason'][0] ) ) ) {
-			/* translators: The reason(s) for rejection. */
 			$reasons         = array();
 			$comment_reasons = Helper_Translation_Discussion::get_comment_reasons();
 			$reasons         = array_map(
@@ -433,7 +432,7 @@ class GP_Notifications {
 				},
 				maybe_unserialize( $comment_meta['reject_reason'][0] )
 			);
-
+			/* translators: The reason(s) for rejection. */
 			$output .= '- ' . wp_kses( sprintf( __( '<strong>Reason:</strong> %s', 'glotpress' ), implode( ', ', $reasons ) ), array( 'strong' => array() ) ) . '<br/>';
 		}
 		/* translators: The comment made. */

--- a/includes/class-gp-notifications.php
+++ b/includes/class-gp-notifications.php
@@ -421,7 +421,7 @@ class GP_Notifications {
 				}
 			}
 		}
-		if ( ! empty( $comment_meta['reject_reason'][0] ) ) {
+		if ( isset( $comment_meta['reject_reason'][0] ) && ! empty( maybe_unserialize( $comment_meta['reject_reason'][0] ) ) ) {
 			$reasons         = array();
 			$comment_reasons = Helper_Translation_Discussion::get_comment_reasons();
 			$reasons         = array_map(

--- a/includes/class-wporg-notifications.php
+++ b/includes/class-wporg-notifications.php
@@ -326,7 +326,6 @@ class WPorg_GlotPress_Notifications {
 			}
 		}
 		if ( array_key_exists( 'reject_reason', $comment_meta ) && ( ! empty( $comment_meta['reject_reason'][0] ) ) ) {
-			/* translators: The reason(s) for rejection. */
 			$reasons         = array();
 			$comment_reasons = Helper_Translation_Discussion::get_comment_reasons();
 			$reasons         = array_map(

--- a/includes/class-wporg-notifications.php
+++ b/includes/class-wporg-notifications.php
@@ -325,7 +325,7 @@ class WPorg_GlotPress_Notifications {
 				$output .= '- <strong>' . esc_html__( 'Translation string: ' ) . '</strong>' . esc_html( $translation->translation_0 ) . '<br>';
 			}
 		}
-		if ( array_key_exists( 'reject_reason', $comment_meta ) && ( ! empty( $comment_meta['reject_reason'][0] ) ) ) {
+		if ( ! empty( $comment_meta['reject_reason'][0] ) ) {
 			$reasons         = array();
 			$comment_reasons = Helper_Translation_Discussion::get_comment_reasons();
 			$reasons         = array_map(

--- a/includes/class-wporg-notifications.php
+++ b/includes/class-wporg-notifications.php
@@ -325,7 +325,7 @@ class WPorg_GlotPress_Notifications {
 				$output .= '- <strong>' . esc_html__( 'Translation string: ' ) . '</strong>' . esc_html( $translation->translation_0 ) . '<br>';
 			}
 		}
-		if ( ! empty( $comment_meta['reject_reason'][0] ) ) {
+		if ( isset( $comment_meta['reject_reason'][0] ) && ! empty( maybe_unserialize( $comment_meta['reject_reason'][0] ) ) ) {
 			$reasons         = array();
 			$comment_reasons = Helper_Translation_Discussion::get_comment_reasons();
 			$reasons         = array_map(

--- a/includes/class-wporg-notifications.php
+++ b/includes/class-wporg-notifications.php
@@ -325,6 +325,20 @@ class WPorg_GlotPress_Notifications {
 				$output .= '- <strong>' . esc_html__( 'Translation string: ' ) . '</strong>' . esc_html( $translation->translation_0 ) . '<br>';
 			}
 		}
+		if ( array_key_exists( 'reject_reason', $comment_meta ) && ( ! empty( $comment_meta['reject_reason'][0] ) ) ) {
+			/* translators: The reason(s) for rejection. */
+			$reasons         = array();
+			$comment_reasons = Helper_Translation_Discussion::get_comment_reasons();
+			$reasons         = array_map(
+				function( $reason ) use ( $comment_reasons ) {
+					if ( array_key_exists( $reason, $comment_reasons ) ) {
+						return $comment_reasons[ $reason ]['name'];
+					}
+				},
+				maybe_unserialize( $comment_meta['reject_reason'][0] )
+			);
+			$output         .= '- <strong>' . esc_html__( 'Reason: ' ) . '</strong>' . esc_html( implode( ', ', $reasons ) ) . '<br>';
+		}
 		$output .= '- <strong>' . esc_html__( 'Comment: ' ) . '</strong>' . esc_html( $comment->comment_content ) . '</pre>';
 		$output .= '<br><br>';
 		$output .= esc_html__( 'Have a nice day' );

--- a/includes/class-wporg-notifications.php
+++ b/includes/class-wporg-notifications.php
@@ -336,7 +336,7 @@ class WPorg_GlotPress_Notifications {
 				},
 				maybe_unserialize( $comment_meta['reject_reason'][0] )
 			);
-			$output         .= '- <strong>' . esc_html__( 'Reason: ' ) . '</strong>' . esc_html( implode( ', ', $reasons ) ) . '<br>';
+			$output         .= '- <strong>' . esc_html__( 'Reason(s): ' ) . '</strong>' . esc_html( implode( ', ', $reasons ) ) . '<br>';
 		}
 		$output .= '- <strong>' . esc_html__( 'Comment: ' ) . '</strong>' . esc_html( $comment->comment_content ) . '</pre>';
 		$output .= '<br><br>';


### PR DESCRIPTION
#### Problem

In the email sent when a translation is rejected, the reason for rejection is not added.

#### Solution

This PR adds the reason for rejection to the body of the email sent when a translation is rejected.

#### Testing instructions

- Suggest a translation as a user
- Reject the translation as another user
- Check the body of email sent and you will see the item "Reason" on the list (see screenshot below)

<img width="622" alt="Screenshot 2022-08-15 at 19 38 31" src="https://user-images.githubusercontent.com/2834132/184695658-2ef6bcfd-c2a2-4219-a895-374f1b870e97.png">

