### PR TITLE
Bulk Reject: Generate better error

### DIFF
--- a/includes/class-gp-translation-helpers.php
+++ b/includes/class-gp-translation-helpers.php
@@ -403,7 +403,7 @@ class GP_Translation_Helpers {
 		$comment              = sanitize_text_field( $_POST['data']['comment'] );
 
 		if ( ! $locale_slug || ! $translation_id_array || ! $original_id_array || ( ! $comment_reason && ! $comment ) ) {
-			wp_send_json_error();
+			wp_send_json_error( 'Oops! One or more required parameters missing' );
 		}
 
 		// Get original_id and translation_id of first string in the array

--- a/includes/class-gp-translation-helpers.php
+++ b/includes/class-gp-translation-helpers.php
@@ -402,8 +402,17 @@ class GP_Translation_Helpers {
 		);
 		$comment              = sanitize_text_field( $_POST['data']['comment'] );
 
-		if ( ! $locale_slug || ! $translation_id_array || ! $original_id_array || ( ! $comment_reason && ! $comment ) ) {
-			wp_send_json_error( 'Oops! One or more required parameters missing' );
+		if ( ! $locale_slug ) {
+			wp_send_json_error( 'Oops! Locale slug missing' );
+		}
+		if ( ! $translation_id_array ) {
+			wp_send_json_error( 'Oops! Translation ID missing' );
+		}
+		if ( ! $original_id_array ) {
+			wp_send_json_error( 'Oops! Original ID missing' );
+		}
+		if ( ! $comment_reason && ! $comment ) {
+			wp_send_json_error( 'Oops! No comment and reason found' );
 		}
 
 		// Get original_id and translation_id of first string in the array

--- a/js/reject-feedback.js
+++ b/js/reject-feedback.js
@@ -164,6 +164,8 @@
 			}
 		).fail(
 			function( xhr, msg ) {
+				// Todo: Remove after debugging is complete
+				console.error( data );
 				msg = 'An error has occurred';
 				if ( xhr.responseText ) {
 					msg += ': ' + xhr.responseText;

--- a/js/reject-feedback.js
+++ b/js/reject-feedback.js
@@ -164,14 +164,13 @@
 			}
 		).fail(
 			function( xhr, msg ) {
-				// Todo: Remove console output after debugging is completed
 				/* eslint no-console: ["error", { allow: ["error"] }] */
 				console.error( data );
 				msg = 'An error has occurred';
 				if ( xhr.responseText ) {
 					msg += ': ' + xhr.responseText;
 				}
-				msg += '. Please, take a screenshot, send it to the developers, and reload the page to see if it still worked.';
+				msg += '. Please, take a screenshot of the output in the browser console, send it to the developers, and reload the page to see if it works.';
 				$gp.notices.error( msg );
 			}
 		);

--- a/js/reject-feedback.js
+++ b/js/reject-feedback.js
@@ -1,4 +1,4 @@
-/* global $gp, $gp_comment_feedback_settings, document, tb_show */
+/* global $gp, $gp_comment_feedback_settings, document, tb_show, console */
 ( function( $, $gp ) {
 	$( document ).ready(
 		function() {
@@ -164,7 +164,8 @@
 			}
 		).fail(
 			function( xhr, msg ) {
-				// Todo: Remove after debugging is complete
+				// Todo: Remove console output after debugging is completed
+				/* eslint no-console: ["error", { allow: ["error"] }] */
 				console.error( data );
 				msg = 'An error has occurred';
 				if ( xhr.responseText ) {


### PR DESCRIPTION
#### Problem

In order to fix this issue -> #97 , we need to be able to tell what the specific error is.

#### Solution

In this PR, I have added an error message to be returned in the ajax call and also show the input data in the console for proper debugging. After this issue has been fixed, the `console.error( data )` will be removed.

#### Testing instructions

When doing a bulk reject with feedback as mentioned in #97, the input data should be displayed in the browser console and a non-generic error message should be shown to the user.

