### PR TITLE
Resolves the error type in the is_global_optout_email_address method when the parameter is null

### DIFF
--- a/includes/class-wporg-notifications.php
+++ b/includes/class-wporg-notifications.php
@@ -445,11 +445,14 @@ class WPorg_GlotPress_Notifications {
 	 *
 	 * @since 0.0.2
 	 *
-	 * @param string $email_address The user's email address.
+	 * @param string|null $email_address The user's email address.
 	 *
-	 * @return bool Whether a user wis globally opt-out.
+	 * @return bool Whether a user is globally opt-out.
 	 */
-	private static function is_global_optout_email_address( string $email_address ): bool {
+	private static function is_global_optout_email_address( ?string $email_address ): bool {
+		if ( is_null( $email_address ) ) {
+			return false;
+		}
 		$user            = get_user_by( 'email', $email_address );
 		$gp_default_sort = get_user_option( 'gp_default_sort', $user->ID );
 		if ( 'on' != gp_array_get( $gp_default_sort, 'notifications_optin', 'off' ) ) {


### PR DESCRIPTION
## Problem

<!--
Please describe what is the status/problem before the PR.
-->

We received this error message:

`Uncaught TypeError: Argument 1 passed to WPorg_GlotPress_Notifications::is_global_optout_email_address() must be of the type string, null given, called in gp-translation-helpers/includes/class-wporg-notifications.php on line 427 `

Fixes https://github.com/GlotPress/gp-translation-helpers/issues/94 

## Solution

This PR adds null as parameter type in the `private static function is_global_optout_email_address( ?string $email_address ): bool` method and check if the email is null inside the method.

<!--
Please describe how this PR improves the situation.
-->



