### PR TITLE
Don't show `This string has no translation in this language.` if there's no locale in the discussions page URL

### DIFF
--- a/templates/original-permalink.php
+++ b/templates/original-permalink.php
@@ -115,10 +115,6 @@ gp_tmpl_header();
 	<p>
 		<a href="<?php echo esc_url( $translate_url ); ?>"><?php esc_html_e( 'This string has no translation in this language.' ); ?></a>
 	</p>
-<?php else : ?>
-	<p>
-		<?php esc_html_e( 'This string has no translation in this language.' ); ?>
-	</p>
 <?php endif; ?>
 <div class="translations" row="<?php echo esc_attr( $row_id . ( $translation ? '-' . $translation->id : '' ) ); ?>" replytocom="<?php echo esc_attr( gp_get( 'replytocom' ) ); ?>" >
 <div class="translation-helpers">


### PR DESCRIPTION
#### Problem

When you visit a discussions page that has no locale in the URL(e.g. https://translate.wordpress.org/projects/wp-plugins/complianz-gdpr/dev-readme/13048945), you find the text "This string has no translation in this language." even if there's already a current/waiting/fuzzy/rejected translation and this is really confusing because when you visit the discussions page with the locale in the URL(e.g https://translate.wordpress.org/projects/wp-plugins/complianz-gdpr/dev-readme/13048945/es/default/) you find out there may be actual translations existing.

#### Solution

Remove the text "This string has no translation in this language." from the discussions page if there's no locale in the discussions page URL


#### Testing instructions

> Before
https://translate.wordpress.org/projects/wp-plugins/complianz-gdpr/dev-readme/13048945
<img width="858" alt="Screenshot 2022-09-13 at 22 03 35" src="https://user-images.githubusercontent.com/2834132/190008983-440e5df7-a5db-4959-8e8b-084b26720c10.png">


> After
https://translate.wordpress.org/projects/wp-plugins/complianz-gdpr/dev-readme/13048945/
<img width="847" alt="image" src="https://user-images.githubusercontent.com/2834132/190008928-10770ebf-3ff7-4acf-a332-d8344b856e5c.png">

