### PR TITLE
Hide new comment form

### DIFF
--- a/css/discussion.css
+++ b/css/discussion.css
@@ -265,8 +265,14 @@ a.comment-reply-link {
 	font-size: .8em;
 }
 .hide-textarea {
+	border: #dfe3e3 thin solid;
+	border-radius: 5px;
+}
+.hide-textarea summary {
 	border: #d0cccc thin solid;
 	background: #e7e7e7;
-	border-radius: 3px;
 	padding: 5px 10px;
+}
+h5#reply-title {
+	padding-left: 13px;
 }

--- a/css/discussion.css
+++ b/css/discussion.css
@@ -268,11 +268,24 @@ a.comment-reply-link {
 	border: #dfe3e3 thin solid;
 	border-radius: 5px;
 	cursor: pointer;
+	width: max-content;
 }
 .hide-textarea summary {
-	border: #d0cccc thin solid;
-	background: #e7e7e7;
 	padding: 5px 10px;
+	background-color: var(--gp-color-btn-primary-bg);
+	border-color: var(--gp-color-btn-primary-border);
+	color: var(--gp-color-btn-primary-text);
+	border-radius: 2px;
+	width: max-content;
+	font-size: 14px;
+	line-height: 20px;
+	font-weight: 500;
+}
+.hide-textarea summary:hover {
+	background-color: var(--gp-color-btn-primary-hover-bg);
+	border-color: var(--gp-color-btn-primary-hover-border);
+	color: var(--gp-color-btn-primary-hover-text);
+	box-shadow: 0 0 0 1px var(--gp-color-canvas-default),0 0 0 2px var(--gp-color-btn-primary-hover-border);
 }
 h5#reply-title {
 	padding-left: 13px;

--- a/css/discussion.css
+++ b/css/discussion.css
@@ -264,3 +264,9 @@ a.comment-reply-link {
 .bulk-comment-item{
 	font-size: .8em;
 }
+.hide-textarea {
+	border: #d0cccc thin solid;
+	background: #e7e7e7;
+	border-radius: 3px;
+	padding: 5px 10px;
+}

--- a/css/discussion.css
+++ b/css/discussion.css
@@ -268,7 +268,7 @@ a.comment-reply-link {
 	border: #dfe3e3 thin solid;
 	border-radius: 5px;
 	cursor: pointer;
-	width: max-content;
+	width: fit-content;
 }
 .hide-textarea summary {
 	padding: 5px 10px;

--- a/css/discussion.css
+++ b/css/discussion.css
@@ -267,7 +267,6 @@ a.comment-reply-link {
 .hide-textarea {
 	border: #dfe3e3 thin solid;
 	border-radius: 5px;
-	cursor: pointer;
 	width: fit-content;
 }
 .hide-textarea summary {
@@ -280,6 +279,7 @@ a.comment-reply-link {
 	font-size: 14px;
 	line-height: 20px;
 	font-weight: 500;
+	cursor: pointer;
 }
 .hide-textarea summary:hover {
 	background-color: var(--gp-color-btn-primary-hover-bg);

--- a/css/discussion.css
+++ b/css/discussion.css
@@ -267,6 +267,7 @@ a.comment-reply-link {
 .hide-textarea {
 	border: #dfe3e3 thin solid;
 	border-radius: 5px;
+	cursor: pointer;
 }
 .hide-textarea summary {
 	border: #d0cccc thin solid;

--- a/helpers-assets/templates/translation-discussion-comments.php
+++ b/helpers-assets/templates/translation-discussion-comments.php
@@ -131,8 +131,8 @@
 		?>
 
 		<?php if ( $comments ) : ?>
-		<details >
-			<summary class="hide-textarea">Start a new conversation</summary>
+		<details class="hide-textarea">
+			<summary>Start a new conversation</summary>
 		<?php endif; ?>
 
 		<?php

--- a/helpers-assets/templates/translation-discussion-comments.php
+++ b/helpers-assets/templates/translation-discussion-comments.php
@@ -128,6 +128,10 @@
 			$post_obj = $post->ID;
 			$_post_id = $post->ID;
 		}
+		?>
+		<details>
+			<summary>Start a new conversation</summary>
+		<?php
 		comment_form(
 			array(
 				'title_reply'         => __( 'Discuss this string' ),
@@ -163,6 +167,9 @@
 			)
 		);
 		echo '</div>';
+		?>
+		</details>
+		<?php
 	} else {
 		/* translators: Log in URL. */
 		echo sprintf( __( 'You have to be <a href="%s">logged in</a> to comment.' ), esc_html( wp_login_url() ) );

--- a/helpers-assets/templates/translation-discussion-comments.php
+++ b/helpers-assets/templates/translation-discussion-comments.php
@@ -131,8 +131,8 @@
 		?>
 
 		<?php if ( $comments ) : ?>
-		<details>
-			<summary>Start a new conversation</summary>
+		<details >
+			<summary class="hide-textarea">Start a new conversation</summary>
 		<?php endif; ?>
 
 		<?php

--- a/helpers-assets/templates/translation-discussion-comments.php
+++ b/helpers-assets/templates/translation-discussion-comments.php
@@ -129,8 +129,12 @@
 			$_post_id = $post->ID;
 		}
 		?>
+
+		<?php if ( $comments ) : ?>
 		<details>
 			<summary>Start a new conversation</summary>
+		<?php endif; ?>
+
 		<?php
 		comment_form(
 			array(
@@ -168,8 +172,12 @@
 		);
 		echo '</div>';
 		?>
-		</details>
-		<?php
+		
+		<?php if ( $comments ) : ?>
+			</details>
+		<?php endif; ?>
+		
+			<?php
 	} else {
 		/* translators: Log in URL. */
 		echo sprintf( __( 'You have to be <a href="%s">logged in</a> to comment.' ), esc_html( wp_login_url() ) );


### PR DESCRIPTION
#### Problem
It's sometimes confusing when you have multiple comment forms displayed at the same time. This is usually the case when a user clicks on the "Reply" button where a new comment form is displayed in addition to the comment form for new comments.

![Screenshot 2022-08-30 at 09-54-37 Visit %s’s website 2 translations](https://user-images.githubusercontent.com/203408/187381878-376e6c35-e822-4b50-9801-215513b4842d.png)

#### Solution

Hide the comment form for new comments
![toggle-comments](https://user-images.githubusercontent.com/203408/187382263-c7114c19-56ac-4bbd-910c-52ba6c4f29dc.gif)

