### PR TITLE
Fix notices introduced in #100

### DIFF
--- a/helpers-assets/templates/translation-discussion-comments.php
+++ b/helpers-assets/templates/translation-discussion-comments.php
@@ -48,6 +48,7 @@
 				'callback'             => 'gth_discussion_callback',
 				'translation_id'       => $translation_id,
 				'locale_slug'          => $locale_slug,
+				'original_permalink'   => $original_permalink,
 				'original_id'          => $original_id,
 				'project'              => $project,
 				'translation_set_slug' => $translation_set_slug,

--- a/helpers-assets/templates/translation-discussion-comments.php
+++ b/helpers-assets/templates/translation-discussion-comments.php
@@ -48,7 +48,6 @@
 				'callback'             => 'gth_discussion_callback',
 				'translation_id'       => $translation_id,
 				'locale_slug'          => $locale_slug,
-				'original_permalink'   => $original_permalink,
 				'original_id'          => $original_id,
 				'project'              => $project,
 				'translation_set_slug' => $translation_set_slug,

--- a/helpers/helper-translation-discussion.php
+++ b/helpers/helper-translation-discussion.php
@@ -558,6 +558,7 @@ class Helper_Translation_Discussion extends GP_Translation_Helper {
 				'post'                 => $post,
 				'translation_id'       => isset( $this->data['translation_id'] ) ? $this->data['translation_id'] : null,
 				'locale_slug'          => $this->data['locale_slug'],
+				'original_permalink'   => $this->data['original_permalink'],
 				'original_id'          => $this->data['original_id'],
 				'project'              => $this->data['project'],
 				'translation_set_slug' => $this->data['translation_set_slug'],

--- a/helpers/helper-translation-discussion.php
+++ b/helpers/helper-translation-discussion.php
@@ -671,7 +671,7 @@ class Helper_Translation_Discussion extends GP_Translation_Helper {
 	 *
 	 * @param      string  $link     The link.
 	 * @param      array   $args     The arguments.
-	 * @param      string  $comment  The comment.
+	 * @param      object  $comment  The comment.
 	 * @param      WP_Post $post     The post.
 	 *
 	 * @return     string  Return the reply link HTML.

--- a/templates/discussions-dashboard.php
+++ b/templates/discussions-dashboard.php
@@ -60,18 +60,12 @@ foreach ( $comments as $_comment ) {
 
 // If the referenced comment is not in the current batch of comments we need to re-add it.
 foreach ( $bulk_comments as $original_id => $_post_id ) {
-	if ( ! isset( $comments_by_post_id[ $_comment->comment_post_ID ] ) ) {
+	if ( ! isset( $comments_by_post_id[ $_post_id ] ) ) {
 		$linked_comment = $_comment->comment_content;
 		$parts          = wp_parse_url( $linked_comment );
 		$comment_id     = intval( str_replace( 'comment-', '', $parts['fragment'] ) );
 		if ( $comment_id ) {
-			$_comment = get_comment( $comment_id );
-			if ( $_comment ) {
-				$comments_by_post_id[ $_comment->comment_post_ID ][] = $_comment;
-				if ( ! isset( $latest_comment_date_by_post_id[ $_comment->comment_post_ID ] ) ) {
-					$latest_comment_date_by_post_id[ $_comment->comment_post_ID ] = $_comment->comment_date;
-				}
-			}
+			$comments_by_post_id[ $_post_id ][] = get_comment( $comment_id );
 		}
 	}
 }

--- a/templates/discussions-dashboard.php
+++ b/templates/discussions-dashboard.php
@@ -65,7 +65,13 @@ foreach ( $bulk_comments as $original_id => $_post_id ) {
 		$parts          = wp_parse_url( $linked_comment );
 		$comment_id     = intval( str_replace( 'comment-', '', $parts['fragment'] ) );
 		if ( $comment_id ) {
-			$comments_by_post_id[ $_comment->comment_post_ID ][] = get_comment( $comment_id );
+			$_comment = get_comment( $comment_id );
+			if ( $_comment ) {
+				$comments_by_post_id[ $_comment->comment_post_ID ][] = $_comment;
+				if ( ! isset( $latest_comment_date_by_post_id[ $_comment->comment_post_ID ] ) ) {
+					$latest_comment_date_by_post_id[ $_comment->comment_post_ID ] = $_comment->comment_date;
+				}
+			}
 		}
 	}
 }

--- a/templates/discussions-dashboard.php
+++ b/templates/discussions-dashboard.php
@@ -48,7 +48,6 @@ foreach ( $comments as $_comment ) {
 		$comments_by_post_id[ $_comment->comment_post_ID ] = array();
 	}
 
-
 	$comments_by_post_id[ $_comment->comment_post_ID ][] = $_comment;
 
 	if ( ! isset( $latest_comment_date_by_post_id[ $_comment->comment_post_ID ] ) ) {
@@ -75,10 +74,10 @@ foreach ( $bulk_comments as $original_id => $_comments ) {
 	}
 }
 
-uasort(
+uksort(
 	$comments_by_post_id,
 	function( $a, $b ) use ( $latest_comment_date_by_post_id ) {
-		return $latest_comment_date_by_post_id[ $b->comment_post_ID ] <=> $latest_comment_date_by_post_id[ $a->comment_post_ID ];
+		return $latest_comment_date_by_post_id[ $b ] <=> $latest_comment_date_by_post_id[ $a ];
 	}
 );
 

--- a/templates/discussions-dashboard.php
+++ b/templates/discussions-dashboard.php
@@ -59,13 +59,15 @@ foreach ( $comments as $_comment ) {
 }
 
 // If the referenced comment is not in the current batch of comments we need to re-add it.
-foreach ( $bulk_comments as $original_id => $_post_id ) {
-	if ( ! isset( $comments_by_post_id[ $_post_id ] ) ) {
-		$linked_comment = $_comment->comment_content;
-		$parts          = wp_parse_url( $linked_comment );
-		$comment_id     = intval( str_replace( 'comment-', '', $parts['fragment'] ) );
-		if ( $comment_id ) {
-			$comments_by_post_id[ $_post_id ][] = get_comment( $comment_id );
+foreach ( $bulk_comments as $original_id => $_comments ) {
+	foreach ( $_comments as $_comment ) {
+		if ( ! isset( $comments_by_post_id[ $_comment->comment_post_ID ] ) ) {
+			$linked_comment = $_comment->comment_content;
+			$parts          = wp_parse_url( $linked_comment );
+			$comment_id     = intval( str_replace( 'comment-', '', $parts['fragment'] ) );
+			if ( $comment_id ) {
+				$comments_by_post_id[ $_comment->comment_post_ID ][] = get_comment( $comment_id );
+			}
 		}
 	}
 }

--- a/templates/discussions-dashboard.php
+++ b/templates/discussions-dashboard.php
@@ -67,6 +67,9 @@ foreach ( $bulk_comments as $original_id => $_comments ) {
 			$comment_id     = intval( str_replace( 'comment-', '', $parts['fragment'] ) );
 			if ( $comment_id ) {
 				$comments_by_post_id[ $_comment->comment_post_ID ][] = get_comment( $comment_id );
+				if ( ! isset( $latest_comment_date_by_post_id[ $_comment->comment_post_ID ] ) ) {
+					$latest_comment_date_by_post_id[ $_comment->comment_post_ID ] = $_comment->comment_date;
+				}
 			}
 		}
 	}


### PR DESCRIPTION
#### Problem

#100 introduced two notices:
```
E_NOTICE: Undefined variable: original_permalink in helpers-assets/templates/translation-discussion-comments.php:51
```

and

```
E_NOTICE: Trying to get property 'comment_post_ID' of non-object in templates/discussions-dashboard.php:76
```

#### Solution

This adds more checks to avoid the notices.
