### PR TITLE
Allow only GTEs view discussions dashboard

### DIFF
--- a/includes/class-gp-route-translation-helpers.php
+++ b/includes/class-gp-route-translation-helpers.php
@@ -35,9 +35,15 @@ class GP_Route_Translation_Helpers extends GP_Route {
 	 * @return void
 	 */
 	public function discussions_dashboard( $locale_slug ) {
-		if ( ! is_user_logged_in() ) {
-			$this->die_with_404();
+		$roles_adapter = null;
+		$user          = wp_get_current_user();
+		$user_email    = $user->user_email;
+
+		$emails_for_locale_gtes = WPorg_GlotPress_Notifications::get_gte_email_addresses( $locale_slug );
+		if ( ! is_user_logged_in() || ! in_array( $user_email, $emails_for_locale_gtes ) ) {
+				$this->die_with_404();
 		}
+
 		$all_comments_count  = count(
 			get_comments(
 				array(


### PR DESCRIPTION
#### Problem

At the moment the link to the discussions dashboard is not displayed for non-GTEs and admins. However, anyone with the URL or that can guess the URL can paste it in the browser and the page would load for them, this should not be possible.


#### Solution


When unauthorised users try to access the dashboard, they should get a 404.

#### Testing instructions

Visit the discussions page for a locale where the logged in user is not a GTE, you should get a 404 page

