### PR TITLE
Add info showing to the validators the feedback is public

### DIFF
--- a/css/discussion.css
+++ b/css/discussion.css
@@ -228,6 +228,12 @@ div#TB_ajaxWindowTitle {
 	height: 110px;
 	font-size: 1.1em;
 }
+.feedback-comment .note {
+	font-size: 0.8rem;
+	font-weight: normal;
+	display: inline-block;
+	margin-bottom: 1rem;
+}
 .status-actions details {
 	margin-bottom: 5px;
 }

--- a/templates/translation-row-editor-meta-feedback.php
+++ b/templates/translation-row-editor-meta-feedback.php
@@ -20,6 +20,7 @@
 				<label><?php esc_html_e( 'Comment (Optional)', 'glotpress' ); ?>
 					<textarea name="feedback_comment"></textarea>
 				</label>
+				<label class="note">Please, note that all feedback are visible to the public.</label>
 			</div>
 		</form>
 	</div>

--- a/templates/translation-row-editor-meta-feedback.php
+++ b/templates/translation-row-editor-meta-feedback.php
@@ -20,7 +20,7 @@
 				<label><?php esc_html_e( 'Comment (Optional)', 'glotpress' ); ?>
 					<textarea name="feedback_comment"></textarea>
 				</label>
-				<label class="note">Please, note that all feedback are visible to the public.</label>
+				<label class="note">Please note that all feedback is visible to the public.</label>
 			</div>
 		</form>
 	</div>


### PR DESCRIPTION
## Problem

We don't show to the validators that the feedback will be public, available to all users. 
<!--
Please describe what is the status/problem before the PR.
-->

## Solution

This PR adds a label with this information.

![image](https://user-images.githubusercontent.com/1667814/196226970-b470e46f-ec67-4438-88c6-8180ccc41302.png)

This is the screenshot at translate.w.org

![image](https://user-images.githubusercontent.com/1667814/196228698-85cdede1-4585-4682-b974-4da3c1ad5eb0.png)


<!--
Please describe how this PR improves the situation.
-->

## Testing instructions

Reload the browser and clear the cache to see the new text.
<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

