### PR TITLE
Show the feedback form open by default

### DIFF
--- a/templates/translation-row-editor-meta-feedback.php
+++ b/templates/translation-row-editor-meta-feedback.php
@@ -1,7 +1,7 @@
 <?php if ( ! $can_approve_translation || ! $translation->translation_status ) {
 	return;
 }  ?>
-<details>
+<details open>
 	<summary class="feedback-summary"><?php esc_html_e( 'Give feedback', 'glotpress' ); ?></summary>
 	<div id="feedback-form">
 		<form>


### PR DESCRIPTION
## Problem

The feedback form is not showed, and the users has to open it to work with it. Some users have request to show it by default. Fixes https://github.com/GlotPress/gp-translation-helpers/issues/119.
<!--
Please describe what is the status/problem before the PR.
-->

## Solution

Change the `<details>` default visibility, showing the feedback form by default.

<!--
Please describe how this PR improves the situation.
-->

## Testing instructions

Clear the cache, reload the main translation table, open a row with some translation and you will see the feedback form without doing any extra click.

It works fine at translate.w.org.

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

