### PR TITLE
Add list of links for filters

### DIFF
--- a/includes/class-gp-route-translation-helpers.php
+++ b/includes/class-gp-route-translation-helpers.php
@@ -38,43 +38,41 @@ class GP_Route_Translation_Helpers extends GP_Route {
 		if ( ! is_user_logged_in() ) {
 			$this->die_with_404();
 		}
-		$all_comments_count  = count(
-			get_comments(
-				array(
-					'meta_key'   => 'locale',
-					'meta_value' => $locale_slug,
-				)
-			)
-		);
+		$user_id = wp_get_current_user()->ID;
+
+		$all_comments_post_ids = $this->get_comment_post_ids( $locale_slug );
+		$comments_count        = count( $all_comments_post_ids );
+		$comment_post_ids      = $all_comments_post_ids;
+
+		$participating          = $this->get_user_comments( $locale_slug, $user_id );
+		$participating_post_ids = array_unique( array_column( $participating, 'comment_post_ID' ) );
+
+		$not_participating_post_ids = array_diff( $all_comments_post_ids, $participating_post_ids );
+
 		$comments_per_page   = 12;
-		$total_pages         = (int) ceil( $all_comments_count / $comments_per_page );
-		$page_num_from_query = get_query_var( 'page' );
+		$page_num_from_query = (int) get_query_var( 'page' );
+		$offset              = $page_num_from_query > 0 ? ( $page_num_from_query - 1 ) * $comments_per_page : 0;
 		$filter              = isset( $_GET['filter'] ) ? esc_html( $_GET['filter'] ) : '';
 		$page_number         = ( ! empty( $page_num_from_query ) && is_int( $page_num_from_query ) ) ? $page_num_from_query : 1;
 		$gp_locale           = GP_Locales::by_slug( $locale_slug );
-		$user_id             = wp_get_current_user()->ID;
-		$post_ids            = array();
-		$post_filter_arg     = array();
-		if ( 'participating' == $filter || 'non_participating' == $filter ) {
-			$comments_per_page = 0;
-			$post_ids          = $this->get_user_comments_post_ids( $locale_slug, $user_id );
-			if ( 'participating' == $filter ) {
-				$post_filter_arg = array( 'post__in' => $post_ids );
-			}
-			if ( 'non_participating' == $filter ) {
-				$post_filter_arg = array( 'post__not_in' => $post_ids );
-			}
+		if ( 'participating' == $filter ) {
+			$comment_post_ids = $participating_post_ids;
+			$comments_count   = count( $participating_post_ids );
 		}
-		$args = array_merge(
-			array(
-				'number'     => $comments_per_page,
-				'meta_key'   => 'locale',
-				'meta_value' => $locale_slug,
-				'paged'      => $page_number,
-			),
-			$post_filter_arg
-		);
+		if ( 'not_participating' == $filter ) {
+			$comment_post_ids = $not_participating_post_ids;
+			$comments_count   = count( $not_participating_post_ids );
+		}
+		$total_pages = (int) ceil( $comments_count / $comments_per_page );
 
+		$post_ids = array();
+
+		$post_ids       = array_splice( $comment_post_ids, $offset, $comments_per_page );
+		$args           = array(
+			'meta_key'   => 'locale',
+			'meta_value' => $locale_slug,
+			'post__in'   => $post_ids,
+		);
 		$comments_query = new WP_Comment_Query( $args );
 		$comments       = $comments_query->comments;
 
@@ -399,7 +397,7 @@ class GP_Route_Translation_Helpers extends GP_Route {
 	 *
 	 * @return     array    The array of comment_post_IDs.
 	 */
-	private function get_user_comments_post_ids( $locale_slug, $user_id ) {
+	private function get_user_comments( $locale_slug, $user_id ) {
 		$args     = array(
 			'meta_key'   => 'locale',
 			'meta_value' => $locale_slug,
@@ -408,8 +406,20 @@ class GP_Route_Translation_Helpers extends GP_Route {
 		$query    = new WP_Comment_Query( $args );
 		$comments = $query->comments;
 
-		return array_unique(
-			array_column( $comments, 'comment_post_ID' )
+		return $comments;
+	}
+
+	/**
+	 * Run a query to fetch comment_post_ID of all comments
+	 *
+	 * @param string $locale_slug           The locale slug.
+	 *
+	 * @return array Array of unique comment_post_IDs for all comments.
+	 */
+	private function get_comment_post_ids( $locale_slug ) {
+		global $wpdb;
+		return $wpdb->get_col(
+			"SELECT DISTINCT {$wpdb->comments}.comment_post_ID FROM {$wpdb->comments} INNER JOIN {$wpdb->commentmeta} ON {$wpdb->comments}.comment_ID = {$wpdb->commentmeta}.comment_id WHERE meta_key='locale' AND meta_value='" . $locale_slug . "' ORDER BY comment_date DESC"
 		);
 	}
 }

--- a/includes/class-gp-route-translation-helpers.php
+++ b/includes/class-gp-route-translation-helpers.php
@@ -419,7 +419,10 @@ class GP_Route_Translation_Helpers extends GP_Route {
 	private function get_comment_post_ids( $locale_slug ) {
 		global $wpdb;
 		return $wpdb->get_col(
-			"SELECT DISTINCT {$wpdb->comments}.comment_post_ID FROM {$wpdb->comments} INNER JOIN {$wpdb->commentmeta} ON {$wpdb->comments}.comment_ID = {$wpdb->commentmeta}.comment_id WHERE meta_key='locale' AND meta_value='" . $locale_slug . "' ORDER BY comment_date DESC"
+			$wpdb->prepare(
+				"SELECT DISTINCT {$wpdb->comments}.comment_post_ID FROM {$wpdb->comments} INNER JOIN {$wpdb->commentmeta} ON {$wpdb->comments}.comment_ID = {$wpdb->commentmeta}.comment_id WHERE meta_key='locale' AND meta_value = %s ORDER BY comment_date DESC",
+				$locale_slug
+			)
 		);
 	}
 }

--- a/includes/class-gp-route-translation-helpers.php
+++ b/includes/class-gp-route-translation-helpers.php
@@ -54,18 +54,26 @@ class GP_Route_Translation_Helpers extends GP_Route {
 		$gp_locale           = GP_Locales::by_slug( $locale_slug );
 		$user_id             = wp_get_current_user()->ID;
 		$post_ids            = array();
-		if ( 'participating' == $filter ) {
+		$post_filter_arg     = array();
+		if ( 'participating' == $filter || 'non-participating' == $filter ) {
 			$comments_per_page = 0;
 			$post_ids          = $this->get_user_comments_post_ids( $locale_slug, $user_id );
-
+			if ( 'participating' == $filter ) {
+				$post_filter_arg = array( 'post__in' => $post_ids );
+			}
+			if ( 'non_participating' == $filter ) {
+				$post_filter_arg = array( 'post__not_in' => $post_ids );
+			}
 		}
 
-		$args = array(
-			'number'     => $comments_per_page,
-			'meta_key'   => 'locale',
-			'meta_value' => $locale_slug,
-			'paged'      => $page_number,
-			'post__in'   => $post_ids,
+		$args = array_merge(
+			array(
+				'number'     => $comments_per_page,
+				'meta_key'   => 'locale',
+				'meta_value' => $locale_slug,
+				'paged'      => $page_number,
+			),
+			$post_filter_arg
 		);
 
 		$comments_query = new WP_Comment_Query( $args );

--- a/includes/class-gp-route-translation-helpers.php
+++ b/includes/class-gp-route-translation-helpers.php
@@ -49,18 +49,20 @@ class GP_Route_Translation_Helpers extends GP_Route {
 		$comments_per_page   = 12;
 		$total_pages         = (int) ceil( $all_comments_count / $comments_per_page );
 		$page_num_from_query = get_query_var( 'page' );
+		$filter              = esc_html( $_GET['filter'] );
 		$page_number         = ( ! empty( $page_num_from_query ) && is_int( $page_num_from_query ) ) ? $page_num_from_query : 1;
 		$gp_locale           = GP_Locales::by_slug( $locale_slug );
+		$user_id             = ( $filter == 'participating' || $filter == 'non_participating' ) ? wp_get_current_user()->ID : '';
 		$args                = array(
 			'number'     => $comments_per_page,
 			'meta_key'   => 'locale',
 			'meta_value' => $locale_slug,
 			'paged'      => $page_number,
+			'user_id'    => $user_id,
 		);
 
 		$comments_query = new WP_Comment_Query( $args );
 		$comments       = $comments_query->comments;
-
 		$this->tmpl( 'discussions-dashboard', get_defined_vars() );
 	}
 

--- a/includes/class-gp-route-translation-helpers.php
+++ b/includes/class-gp-route-translation-helpers.php
@@ -55,7 +55,7 @@ class GP_Route_Translation_Helpers extends GP_Route {
 		$user_id             = wp_get_current_user()->ID;
 		$post_ids            = array();
 		$post_filter_arg     = array();
-		if ( 'participating' == $filter || 'non-participating' == $filter ) {
+		if ( 'participating' == $filter || 'non_participating' == $filter ) {
 			$comments_per_page = 0;
 			$post_ids          = $this->get_user_comments_post_ids( $locale_slug, $user_id );
 			if ( 'participating' == $filter ) {
@@ -65,7 +65,6 @@ class GP_Route_Translation_Helpers extends GP_Route {
 				$post_filter_arg = array( 'post__not_in' => $post_ids );
 			}
 		}
-
 		$args = array_merge(
 			array(
 				'number'     => $comments_per_page,

--- a/includes/class-gp-route-translation-helpers.php
+++ b/includes/class-gp-route-translation-helpers.php
@@ -49,7 +49,7 @@ class GP_Route_Translation_Helpers extends GP_Route {
 		$comments_per_page   = 12;
 		$total_pages         = (int) ceil( $all_comments_count / $comments_per_page );
 		$page_num_from_query = get_query_var( 'page' );
-		$filter              = esc_html( $_GET['filter'] );
+		$filter              = isset( $_GET['filter'] ) ? esc_html( $_GET['filter'] ) : '';
 		$page_number         = ( ! empty( $page_num_from_query ) && is_int( $page_num_from_query ) ) ? $page_num_from_query : 1;
 		$gp_locale           = GP_Locales::by_slug( $locale_slug );
 		$user_id             = ( $filter == 'participating' || $filter == 'non_participating' ) ? wp_get_current_user()->ID : '';

--- a/templates/discussions-dashboard.php
+++ b/templates/discussions-dashboard.php
@@ -92,8 +92,8 @@ $args = array(
 
 <div class="filter-toolbar">
 	<a class="filter-current" href="">All&nbsp;(<?php echo count( $comments_by_post_id ); ?>)</a> <span class="separator">•</span>
-	<a href="">Participating&nbsp;(0)</a> <span class="separator">•</span>
-	<a href="">Not participating&nbsp;(0)</a>
+	<a href="<?php echo home_url( $_SERVER['REQUEST_URI']) . '?filter=participating'; ?>">Participating&nbsp;(0)</a> <span class="separator">•</span>
+	<a href="<?php echo home_url( $_SERVER['REQUEST_URI']) . '?filter=non_participating'; ?>">Not participating&nbsp;(0)</a>
 </div>
 <table id="translations" class="translations clear">
 	<thead class="discussions-table-head">

--- a/templates/discussions-dashboard.php
+++ b/templates/discussions-dashboard.php
@@ -91,9 +91,9 @@ $args = array(
 ?>
 
 <div class="filter-toolbar">
-	<a class="filter-current" href="<?php echo esc_url( remove_query_arg( array( 'filter', 'page' ) ) ); ?>">All&nbsp;(<?php echo count( $comments_by_post_id ); ?>)</a> <span class="separator">•</span>
-	<a href="<?php echo esc_url( add_query_arg( 'filter', 'participating', $_SERVER['REQUEST_URI'] ) ); ?>">Participating&nbsp;(0)</a> <span class="separator">•</span>
-	<a href="<?php echo esc_url( add_query_arg( 'filter', 'non_participating', $_SERVER['REQUEST_URI'] ) ); ?>">Not participating&nbsp;(0)</a>
+	<a class="filter-current" href="<?php echo esc_url( remove_query_arg( array( 'filter', 'page' ) ) ); ?>">All&nbsp;(<?php echo count( $all_comments_post_ids ); ?>)</a> <span class="separator">•</span>
+	<a href="<?php echo esc_url( add_query_arg( 'filter', 'participating', $_SERVER['REQUEST_URI'] ) ); ?>">Participating&nbsp;(<?php echo count( $participating_post_ids ); ?>)</a> <span class="separator">•</span>
+	<a href="<?php echo esc_url( add_query_arg( 'filter', 'not_participating', $_SERVER['REQUEST_URI'] ) ); ?>">Not participating&nbsp;(<?php echo count( $not_participating_post_ids ); ?>)</a>
 </div>
 <table id="translations" class="translations clear">
 	<thead class="discussions-table-head">

--- a/templates/discussions-dashboard.php
+++ b/templates/discussions-dashboard.php
@@ -92,8 +92,8 @@ $args = array(
 
 <div class="filter-toolbar">
 	<a class="filter-current" href="">All&nbsp;(<?php echo count( $comments_by_post_id ); ?>)</a> <span class="separator">•</span>
-	<a href="<?php echo home_url( $_SERVER['REQUEST_URI']) . '?filter=participating'; ?>">Participating&nbsp;(0)</a> <span class="separator">•</span>
-	<a href="<?php echo home_url( $_SERVER['REQUEST_URI']) . '?filter=non_participating'; ?>">Not participating&nbsp;(0)</a>
+	<a href="<?php echo add_query_arg( 'filter', 'participating', $_SERVER['REQUEST_URI'] ); ?>">Participating&nbsp;(0)</a> <span class="separator">•</span>
+	<a href="<?php echo add_query_arg( 'filter', 'non_participating', $_SERVER['REQUEST_URI'] ); ?>">Not participating&nbsp;(0)</a>
 </div>
 <table id="translations" class="translations clear">
 	<thead class="discussions-table-head">

--- a/templates/discussions-dashboard.php
+++ b/templates/discussions-dashboard.php
@@ -88,10 +88,13 @@ $args = array(
 	'reverse_children' => false,
 );
 
-
-
 ?>
 
+<div class="filter-toolbar">
+	<a class="filter-current" href="">All&nbsp;(<?php echo count( $comments_by_post_id ); ?>)</a> <span class="separator">•</span>
+	<a href="">Participating&nbsp;(0)</a> <span class="separator">•</span>
+	<a href="">Not participating&nbsp;(0)</a>
+</div>
 <table id="translations" class="translations clear">
 	<thead class="discussions-table-head">
 	<tr>

--- a/templates/discussions-dashboard.php
+++ b/templates/discussions-dashboard.php
@@ -91,9 +91,9 @@ $args = array(
 ?>
 
 <div class="filter-toolbar">
-	<a class="filter-current" href="">All&nbsp;(<?php echo count( $comments_by_post_id ); ?>)</a> <span class="separator">•</span>
-	<a href="<?php echo add_query_arg( 'filter', 'participating', $_SERVER['REQUEST_URI'] ); ?>">Participating&nbsp;(0)</a> <span class="separator">•</span>
-	<a href="<?php echo add_query_arg( 'filter', 'non_participating', $_SERVER['REQUEST_URI'] ); ?>">Not participating&nbsp;(0)</a>
+	<a class="filter-current" href="<?php echo esc_url( remove_query_arg( array( 'filter', 'page' ) ) ); ?>">All&nbsp;(<?php echo count( $comments_by_post_id ); ?>)</a> <span class="separator">•</span>
+	<a href="<?php echo esc_url( add_query_arg( 'filter', 'participating', $_SERVER['REQUEST_URI'] ) ); ?>">Participating&nbsp;(0)</a> <span class="separator">•</span>
+	<a href="<?php echo esc_url( add_query_arg( 'filter', 'non_participating', $_SERVER['REQUEST_URI'] ) ); ?>">Not participating&nbsp;(0)</a>
 </div>
 <table id="translations" class="translations clear">
 	<thead class="discussions-table-head">

--- a/templates/discussions-dashboard.php
+++ b/templates/discussions-dashboard.php
@@ -91,9 +91,9 @@ $args = array(
 ?>
 
 <div class="filter-toolbar">
-	<a class="<?php echo ! $filter ? 'filter-current' : ''; ?>" href="<?php echo esc_url( remove_query_arg( array( 'filter', 'page' ) ) ); ?>">All&nbsp;(<?php echo count( $all_comments_post_ids ); ?>)</a> <span class="separator">•</span>
-	<a class="<?php echo ( 'participating' === $filter ) ? 'filter-current' : ''; ?>" href="<?php echo esc_url( add_query_arg( 'filter', 'participating', $_SERVER['REQUEST_URI'] ) ); ?>">Participating&nbsp;(<?php echo count( $participating_post_ids ); ?>)</a> <span class="separator">•</span>
-	<a class="<?php echo ( 'not_participating' === $filter ) ? 'filter-current' : ''; ?>" href="<?php echo esc_url( add_query_arg( 'filter', 'not_participating', $_SERVER['REQUEST_URI'] ) ); ?>">Not participating&nbsp;(<?php echo count( $not_participating_post_ids ); ?>)</a>
+	<a class="<?php echo ( ! $filter ) ? 'filter-current' : ''; ?>" href="<?php echo esc_url( remove_query_arg( array( 'filter', 'page' ) ) ); ?>">All&nbsp;(<?php echo esc_html( count( $all_comments_post_ids ) ); ?>)</a> <span class="separator">•</span>
+	<a class="<?php echo ( 'participating' === $filter ) ? 'filter-current' : ''; ?>" href="<?php echo esc_url( add_query_arg( 'filter', 'participating', $_SERVER['REQUEST_URI'] ) ); ?>">Participating&nbsp;(<?php echo esc_html( count( $participating_post_ids ) ); ?>)</a> <span class="separator">•</span>
+	<a class="<?php echo ( 'not_participating' === $filter ) ? 'filter-current' : ''; ?>" href="<?php echo esc_url( add_query_arg( 'filter', 'not_participating', $_SERVER['REQUEST_URI'] ) ); ?>">Not participating&nbsp;(<?php echo esc_html( count( $not_participating_post_ids ) ); ?>)</a>
 </div>
 <table id="translations" class="translations clear">
 	<thead class="discussions-table-head">

--- a/templates/discussions-dashboard.php
+++ b/templates/discussions-dashboard.php
@@ -92,8 +92,8 @@ $args = array(
 
 <div class="filter-toolbar">
 	<a class="<?php echo ! $filter ? 'filter-current' : ''; ?>" href="<?php echo esc_url( remove_query_arg( array( 'filter', 'page' ) ) ); ?>">All&nbsp;(<?php echo count( $all_comments_post_ids ); ?>)</a> <span class="separator">•</span>
-	<a class="<?php echo ( $filter === 'participating' ) ? 'filter-current' : ''; ?>" href="<?php echo esc_url( add_query_arg( 'filter', 'participating', $_SERVER['REQUEST_URI'] ) ); ?>">Participating&nbsp;(<?php echo count( $participating_post_ids ); ?>)</a> <span class="separator">•</span>
-	<a class="<?php echo ( $filter === 'not_participating' ) ? 'filter-current' : ''; ?>" href="<?php echo esc_url( add_query_arg( 'filter', 'not_participating', $_SERVER['REQUEST_URI'] ) ); ?>">Not participating&nbsp;(<?php echo count( $not_participating_post_ids ); ?>)</a>
+	<a class="<?php echo ( 'participating' === $filter ) ? 'filter-current' : ''; ?>" href="<?php echo esc_url( add_query_arg( 'filter', 'participating', $_SERVER['REQUEST_URI'] ) ); ?>">Participating&nbsp;(<?php echo count( $participating_post_ids ); ?>)</a> <span class="separator">•</span>
+	<a class="<?php echo ( 'not_participating' === $filter ) ? 'filter-current' : ''; ?>" href="<?php echo esc_url( add_query_arg( 'filter', 'not_participating', $_SERVER['REQUEST_URI'] ) ); ?>">Not participating&nbsp;(<?php echo count( $not_participating_post_ids ); ?>)</a>
 </div>
 <table id="translations" class="translations clear">
 	<thead class="discussions-table-head">

--- a/templates/discussions-dashboard.php
+++ b/templates/discussions-dashboard.php
@@ -91,9 +91,9 @@ $args = array(
 ?>
 
 <div class="filter-toolbar">
-	<a class="filter-current" href="<?php echo esc_url( remove_query_arg( array( 'filter', 'page' ) ) ); ?>">All&nbsp;(<?php echo count( $all_comments_post_ids ); ?>)</a> <span class="separator">•</span>
-	<a href="<?php echo esc_url( add_query_arg( 'filter', 'participating', $_SERVER['REQUEST_URI'] ) ); ?>">Participating&nbsp;(<?php echo count( $participating_post_ids ); ?>)</a> <span class="separator">•</span>
-	<a href="<?php echo esc_url( add_query_arg( 'filter', 'not_participating', $_SERVER['REQUEST_URI'] ) ); ?>">Not participating&nbsp;(<?php echo count( $not_participating_post_ids ); ?>)</a>
+	<a class="<?php echo ! $filter ? 'filter-current' : ''; ?>" href="<?php echo esc_url( remove_query_arg( array( 'filter', 'page' ) ) ); ?>">All&nbsp;(<?php echo count( $all_comments_post_ids ); ?>)</a> <span class="separator">•</span>
+	<a class="<?php echo ( $filter === 'participating' ) ? 'filter-current' : ''; ?>" href="<?php echo esc_url( add_query_arg( 'filter', 'participating', $_SERVER['REQUEST_URI'] ) ); ?>">Participating&nbsp;(<?php echo count( $participating_post_ids ); ?>)</a> <span class="separator">•</span>
+	<a class="<?php echo ( $filter === 'not_participating' ) ? 'filter-current' : ''; ?>" href="<?php echo esc_url( add_query_arg( 'filter', 'not_participating', $_SERVER['REQUEST_URI'] ) ); ?>">Not participating&nbsp;(<?php echo count( $not_participating_post_ids ); ?>)</a>
 </div>
 <table id="translations" class="translations clear">
 	<thead class="discussions-table-head">


### PR DESCRIPTION
#### Problem

Can't filter discussions to identify discussions needing responses.
#### Solution

We'll add the ability to filter discussions based on whether the user has participated in it, not participated by clicking the filter links on top of the table.
![Screenshot 2022-10-24 at 14 54 02](https://user-images.githubusercontent.com/2834132/197542748-77d50591-72fd-421d-bb45-ab52bf2e575b.png)




