### PR TITLE
Add GTEs/PTEs Involved column

### DIFF
--- a/css/discussion.css
+++ b/css/discussion.css
@@ -297,19 +297,22 @@ h5#reply-title {
 	padding-left: 13px;
 }
 ul#glossary-item-list {
-    list-style-type: none;
+	list-style-type: none;
 	border: #bcc3c3 thin solid;
-    padding: 10px;
-    border-radius: 3px;
-    background: #f2f2f2;
+	padding: 10px;
+	border-radius: 3px;
+	background: #f2f2f2;
 }
 ul#glossary-item-list h6 {
 	margin-top: 3px;
-    margin-bottom: 8px
+	margin-bottom: 8px
 }
 ul#glossary-item-list li label {
-    margin-left: 5px;
+	margin-left: 5px;
 }
 #glossary-item-list li label input[type="checkbox"].glossary-word-item {
-    margin-right: 5px;
+	margin-right: 5px;
+}
+td.gtes-involved a{
+	text-decoration: none;
 }

--- a/includes/class-wporg-customizations.php
+++ b/includes/class-wporg-customizations.php
@@ -59,7 +59,8 @@ class WPorg_GlotPress_Customizations {
 					$gte_emails   = WPorg_GlotPress_Notifications::get_gte_email_addresses( $locale_slug );
 					$pte_emails   = WPorg_GlotPress_Notifications::get_pte_email_addresses_by_project_and_locale( $original_id, $locale_slug );
 					$clpte_emails = WPorg_GlotPress_Notifications::get_clpte_email_addresses_by_project( $original_id );
-					return array_intersect( array_merge( $clpte_emails, array_merge( $gte_emails, $pte_emails ) ), $comment_authors );
+					return array_intersect( array_merge( $gte_emails, $pte_emails, $clpte_emails ), $comment_authors );
+
 				},
 				10,
 				4

--- a/includes/class-wporg-customizations.php
+++ b/includes/class-wporg-customizations.php
@@ -69,7 +69,7 @@ class WPorg_GlotPress_Customizations {
 			add_filter(
 				'gp_involved_table_heading',
 				function () {
-					return 'GTEs/PTEs/CLPTEs Involved';
+					return __( 'GTEs/PTEs/CLPTEs Involved' );
 				}
 			);
 		}

--- a/includes/class-wporg-customizations.php
+++ b/includes/class-wporg-customizations.php
@@ -54,11 +54,12 @@ class WPorg_GlotPress_Customizations {
 			);
 
 			add_filter(
-				'gp_gtes_ptes_involved',
+				'gp_validators_involved',
 				function ( $gtes_involved, $locale_slug, $original_id, $comment_authors ) {
-					$gte_emails = WPorg_GlotPress_Notifications::get_gte_email_addresses( $locale_slug );
-					$pte_emails = WPorg_GlotPress_Notifications::get_pte_email_addresses_by_project_and_locale( $original_id, $locale_slug );
-					return array_intersect( array_merge( $gte_emails, $pte_emails ), $comment_authors );
+					$gte_emails   = WPorg_GlotPress_Notifications::get_gte_email_addresses( $locale_slug );
+					$pte_emails   = WPorg_GlotPress_Notifications::get_pte_email_addresses_by_project_and_locale( $original_id, $locale_slug );
+					$clpte_emails = WPorg_GlotPress_Notifications::get_clpte_email_addresses_by_project( $original_id );
+					return array_intersect( array_merge( $clpte_emails, array_merge( $gte_emails, $pte_emails ) ), $comment_authors );
 				},
 				10,
 				4
@@ -67,7 +68,7 @@ class WPorg_GlotPress_Customizations {
 			add_filter(
 				'gp_involved_table_heading',
 				function () {
-					return 'GTEs/PTEs Involved';
+					return 'GTEs/PTEs/CLPTEs Involved';
 				}
 			);
 		}

--- a/includes/class-wporg-customizations.php
+++ b/includes/class-wporg-customizations.php
@@ -53,6 +53,16 @@ class WPorg_GlotPress_Customizations {
 				}
 			);
 
+			add_filter(
+				'gp_gtes_ptes_involved',
+				function ( $gtes_involved, $locale_slug, $original_id, $comment_authors ) {
+					$gte_emails = WPorg_GlotPress_Notifications::get_gte_email_addresses( $locale_slug );
+					$pte_emails = WPorg_GlotPress_Notifications::get_pte_email_addresses_by_project_and_locale( $original_id, $locale_slug );
+					return array_intersect( array_merge( $gte_emails, $pte_emails ), $comment_authors );
+				},
+				10,
+				4
+			);
 		}
 	}
 }

--- a/includes/class-wporg-customizations.php
+++ b/includes/class-wporg-customizations.php
@@ -63,6 +63,13 @@ class WPorg_GlotPress_Customizations {
 				10,
 				4
 			);
+
+			add_filter(
+				'gp_involved_table_heading',
+				function () {
+					return 'GTEs/PTEs Involved';
+				}
+			);
 		}
 	}
 }

--- a/templates/discussions-dashboard.php
+++ b/templates/discussions-dashboard.php
@@ -103,7 +103,7 @@ $args = array(
 		<th>Project</th>
 		<th>Author</th>
 		<th>Submitted on</th>
-		<th>GTEs/PTEs Involved</th>
+		<th><?php echo esc_html( apply_filters( 'gp_involved_table_heading', 'Validators Involved' ) ); ?></th>
 	</tr>
 	</thead>
 	<tbody>

--- a/templates/discussions-dashboard.php
+++ b/templates/discussions-dashboard.php
@@ -103,6 +103,7 @@ $args = array(
 		<th>Project</th>
 		<th>Author</th>
 		<th>Submitted on</th>
+		<th>PTEs/GTEs</th>
 	</tr>
 	</thead>
 	<tbody>
@@ -118,6 +119,10 @@ $args = array(
 			$parent_project = GP::$project->get( $project->parent_project_id );
 			$project_name   = ( $parent_project ) ? $parent_project->name : $project->name;
 			$project_link   = gp_link_project_get( $project, esc_html( $project_name ) );
+
+			$comment_authors  = array_unique( array_column( $post_comments, 'comment_author_email' ) );
+			$validator_emails = GP_Notifications::get_validators_email_addresses( $project->path );
+			$gtes_involved    = array_intersect( $validator_emails, $comment_authors );
 
 			$first_comment        = reset( $post_comments );
 			$no_of_other_comments = count( $post_comments ) - 1;
@@ -200,6 +205,7 @@ $args = array(
 				<td><?php echo wp_kses( $project_link, array( 'a' => array( 'href' => true ) ) ); ?></td>
 				<td><?php echo get_comment_author_link( $first_comment ); ?></td>
 				<td><?php echo esc_html( $first_comment->comment_date ); ?></td>
+				<td><?php echo implode( ',', $gtes_involved ); ?></td>
 			</tr>
 			<?php
 		}

--- a/templates/discussions-dashboard.php
+++ b/templates/discussions-dashboard.php
@@ -103,7 +103,7 @@ $args = array(
 		<th>Project</th>
 		<th>Author</th>
 		<th>Submitted on</th>
-		<th>PTEs/GTEs</th>
+		<th>GTEs/PTEs Involved</th>
 	</tr>
 	</thead>
 	<tbody>
@@ -205,7 +205,7 @@ $args = array(
 				<td><?php echo wp_kses( $project_link, array( 'a' => array( 'href' => true ) ) ); ?></td>
 				<td><?php echo get_comment_author_link( $first_comment ); ?></td>
 				<td><?php echo esc_html( $first_comment->comment_date ); ?></td>
-				<td><?php echo implode( ',', $gtes_involved ); ?></td>
+				<td><?php echo esc_html( implode( ',', $gtes_involved ) ); ?></td>
 			</tr>
 			<?php
 		}

--- a/templates/discussions-dashboard.php
+++ b/templates/discussions-dashboard.php
@@ -129,7 +129,7 @@ $args = array(
 			$validator_involved_names = array_map(
 				function( $validator ) {
 					$validator_user = get_user_by( 'email', $validator );
-					return '<a href="' . esc_url( gp_url_profile( $validator_user->user_nicename ) ) . '">' . esc_html( $validator_user->user_nicename ) . '</a>';
+					return '<a href="' . esc_url( gp_url_profile( $validator_user->user_nicename ) ) . '">' . esc_html( $validator_user->display_name ) . '</a>';
 				},
 				$validators_involved_emails
 			);

--- a/templates/discussions-dashboard.php
+++ b/templates/discussions-dashboard.php
@@ -103,7 +103,7 @@ $args = array(
 		<th>Project</th>
 		<th>Author</th>
 		<th>Submitted on</th>
-		<th><?php echo esc_html( apply_filters( 'gp_involved_table_heading', 'Validators Involved' ) ); ?></th>
+		<th><?php echo esc_html( apply_filters( 'gp_involved_table_heading', __( 'Validators Involved' ) ) ); ?></th>
 	</tr>
 	</thead>
 	<tbody>

--- a/templates/discussions-dashboard.php
+++ b/templates/discussions-dashboard.php
@@ -218,7 +218,7 @@ $args = array(
 				<td>
 					<?php
 						echo wp_kses(
-							implode( ',', $validator_involved_names ),
+							implode( ', ', $validator_involved_names ),
 							array(
 								'a' => array(
 									'href'  => array(),

--- a/templates/discussions-dashboard.php
+++ b/templates/discussions-dashboard.php
@@ -120,9 +120,19 @@ $args = array(
 			$project_name   = ( $parent_project ) ? $parent_project->name : $project->name;
 			$project_link   = gp_link_project_get( $project, esc_html( $project_name ) );
 
-			$comment_authors  = array_unique( array_column( $post_comments, 'comment_author_email' ) );
-			$validator_emails = GP_Notifications::get_validators_email_addresses( $project->path );
-			$gtes_involved    = array_intersect( $validator_emails, $comment_authors );
+			$comment_authors      = array_unique( array_column( $post_comments, 'comment_author_email' ) );
+			$validator_emails     = GP_Notifications::get_validators_email_addresses( $project->path );
+			$gtes_involved_emails = array_intersect( $validator_emails, $comment_authors );
+
+			$gtes_involved_emails = apply_filters( 'gp_gtes_ptes_involved', $gtes_involved_emails, $locale_slug, $original_id, $comment_authors );
+
+			$gte_involved_names = array_map(
+				function( $gte ) {
+					$gte_user = get_user_by( 'email', $gte );
+					return '<a href="' . esc_url( gp_url_profile( $gte_user->user_nicename ) ) . '">' . esc_html( $gte_user->user_nicename ) . '</a>';
+				},
+				$gtes_involved_emails
+			);
 
 			$first_comment        = reset( $post_comments );
 			$no_of_other_comments = count( $post_comments ) - 1;
@@ -205,7 +215,7 @@ $args = array(
 				<td><?php echo wp_kses( $project_link, array( 'a' => array( 'href' => true ) ) ); ?></td>
 				<td><?php echo get_comment_author_link( $first_comment ); ?></td>
 				<td><?php echo esc_html( $first_comment->comment_date ); ?></td>
-				<td><?php echo esc_html( implode( ',', $gtes_involved ) ); ?></td>
+				<td><?php echo implode( ',', $gte_involved_names ); ?></td>
 			</tr>
 			<?php
 		}

--- a/templates/discussions-dashboard.php
+++ b/templates/discussions-dashboard.php
@@ -120,18 +120,18 @@ $args = array(
 			$project_name   = ( $parent_project ) ? $parent_project->name : $project->name;
 			$project_link   = gp_link_project_get( $project, esc_html( $project_name ) );
 
-			$comment_authors      = array_unique( array_column( $post_comments, 'comment_author_email' ) );
-			$validator_emails     = GP_Notifications::get_validators_email_addresses( $project->path );
-			$gtes_involved_emails = array_intersect( $validator_emails, $comment_authors );
+			$comment_authors            = array_unique( array_column( $post_comments, 'comment_author_email' ) );
+			$validator_emails           = GP_Notifications::get_validators_email_addresses( $project->path );
+			$validators_involved_emails = array_intersect( $validator_emails, $comment_authors );
 
-			$gtes_involved_emails = apply_filters( 'gp_gtes_ptes_involved', $gtes_involved_emails, $locale_slug, $original_id, $comment_authors );
+			$validators_involved_emails = apply_filters( 'gp_validators_involved', $validators_involved_emails, $locale_slug, $original_id, $comment_authors );
 
-			$gte_involved_names = array_map(
-				function( $gte ) {
-					$gte_user = get_user_by( 'email', $gte );
-					return '<a href="' . esc_url( gp_url_profile( $gte_user->user_nicename ) ) . '">' . esc_html( $gte_user->user_nicename ) . '</a>';
+			$validator_involved_names = array_map(
+				function( $validator ) {
+					$validator_user = get_user_by( 'email', $validator );
+					return '<a href="' . esc_url( gp_url_profile( $validator_user->user_nicename ) ) . '">' . esc_html( $validator_user->user_nicename ) . '</a>';
 				},
-				$gtes_involved_emails
+				$validators_involved_emails
 			);
 
 			$first_comment        = reset( $post_comments );
@@ -218,7 +218,7 @@ $args = array(
 				<td>
 					<?php
 						echo wp_kses(
-							implode( ',', $gte_involved_names ),
+							implode( ',', $validator_involved_names ),
 							array(
 								'a' => array(
 									'href'  => array(),

--- a/templates/discussions-dashboard.php
+++ b/templates/discussions-dashboard.php
@@ -215,7 +215,19 @@ $args = array(
 				<td><?php echo wp_kses( $project_link, array( 'a' => array( 'href' => true ) ) ); ?></td>
 				<td><?php echo get_comment_author_link( $first_comment ); ?></td>
 				<td><?php echo esc_html( $first_comment->comment_date ); ?></td>
-				<td><?php echo implode( ',', $gte_involved_names ); ?></td>
+				<td>
+					<?php
+						echo wp_kses(
+							implode( ',', $gte_involved_names ),
+							array(
+								'a' => array(
+									'href'  => array(),
+									'class' => array(),
+								),
+							)
+						);
+					?>
+			</td>
 			</tr>
 			<?php
 		}

--- a/templates/discussions-dashboard.php
+++ b/templates/discussions-dashboard.php
@@ -215,7 +215,7 @@ $args = array(
 				<td><?php echo wp_kses( $project_link, array( 'a' => array( 'href' => true ) ) ); ?></td>
 				<td><?php echo get_comment_author_link( $first_comment ); ?></td>
 				<td><?php echo esc_html( $first_comment->comment_date ); ?></td>
-				<td>
+				<td class="gtes-involved">
 					<?php
 						echo wp_kses(
 							implode( ', ', $validator_involved_names ),


### PR DESCRIPTION
#### Problem

On the discussions dashboard, we need to GTEs to be able to see the other GTEs involved in a discussion.

#### Solution

Add column titled "GTEs/PTEs/CLPTEs Involved"
> On translate.wordpress.org

<img width="1205" alt="Screenshot 2022-11-28 at 22 47 07" src="https://user-images.githubusercontent.com/2834132/204397048-66e22dc7-d331-4ce8-a597-606d828d1d0f.png">

> In GlotPress core
<img width="951" alt="Screenshot 2022-11-15 at 07 35 17" src="https://user-images.githubusercontent.com/2834132/201845971-97ce57ca-a71b-42e5-8ffc-65826aa4677e.png">


#### Testing instructions

Visit the discussions dashboard for a locale and the new column should be present.

