### PR TITLE
Disable only Feedback `<summary>` events

### DIFF
--- a/js/reject-feedback.js
+++ b/js/reject-feedback.js
@@ -22,7 +22,7 @@
 			$( 'body' ).append( modalFeedbackForm );
 
 			// Remove click event added to <summary> by wporg-gp-customizations plugin
-			$( $gp.editor.table ).off( 'click', 'summary' );
+			$( $gp.editor.table ).off( 'click', 'summary.feedback-summary' );
 
 			$( '#bulk-actions-toolbar-top .button, #bulk-actions-toolbar-bottom .button' ).click(
 				function( e ) {


### PR DESCRIPTION
In order to restore wporg-gp-customizations behaviour for `<summary>` state we need to only disable the feedback summarry, not all of them.

Fixes #141 

#### Testing instructions

Close/Open Translation Memory suggestions summary and after refreshing the page the state should be kept (wporg-pg-customizations previously blocked by global selector)

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

