### PR TITLE
Add some components to add tabs in the right sidebar

### DIFF
--- a/css/editor.css
+++ b/css/editor.css
@@ -89,10 +89,8 @@ ul.sidebar-tabs {
 
 .meta.discussion .comment-respond{
     padding: 0 1rem;
-    background: red;
 }
 
 .meta.discussion .optin-message-for-each-discussion {
     padding: 0 1rem 1rem 1rem;
-    background: blue;
 }

--- a/css/editor.css
+++ b/css/editor.css
@@ -1,0 +1,42 @@
+.editor .meta {
+    border: 1px solid #ccc;
+    margin-left: -1px !important;
+    width: auto !important;
+}
+
+.editor .nav-sidebar {
+    float: left;
+    width: 35%;
+    margin: 0;
+    padding: 0;
+}
+
+.sidebar-tabs {
+    margin: 0;
+    padding: 0;
+}
+
+ul.sidebar-tabs {
+    margin-bottom: 0;
+}
+
+.sidebar-tabs > li {
+    background: #eee;
+    color: #222;
+    display: inline-block;
+    padding: 10px 15px;
+    cursor: pointer;
+    margin: 0 1px 0 0;
+}
+.sidebar-tabs li.current {
+    background-color: transparent;
+    margin: 0 0 -1px -1px;
+    border: 1px solid #ccc;
+    border-bottom: 1px solid #fff;
+    font-weight: bold;
+}
+
+.meta h3 {
+    display: none !important;
+}
+

--- a/css/editor.css
+++ b/css/editor.css
@@ -87,3 +87,12 @@ ul.sidebar-tabs {
     display: none !important;
 }
 
+.meta.discussion .comment-respond{
+    padding: 0 1rem;
+    background: red;
+}
+
+.meta.discussion .optin-message-for-each-discussion {
+    padding: 0 1rem 1rem 1rem;
+    background: blue;
+}

--- a/css/editor.css
+++ b/css/editor.css
@@ -1,7 +1,47 @@
 .editor .meta {
     border: 1px solid #ccc;
     margin-left: -1px !important;
-    width: auto !important;
+    width: 100% !important;
+    min-width: 500px;
+    min-height: 300px;
+}
+
+.meta.discussion, .meta.history {
+    padding: 1rem;
+}
+.meta.discussion h6 {
+    margin-block: auto;
+}
+
+.meta.history .translations {
+    width: 100%;
+}
+.meta.history #translation-history-table thead tr th {
+    font-size: 0.9rem;
+    font-weight: 500 !important;
+}
+
+.meta.history #legend > div {
+    margin-top: 0.5rem;
+}
+
+.meta.other-locales ul {
+    list-style: none;
+}
+
+.meta.other-locales span.locale.unique {
+    margin-right: 26px;
+}
+
+.meta.other-locales .other-locales .locale {
+    display: inline-block;
+    padding: 1px 6px 0 0;
+    margin: 1px 6px 1px 0;
+    background: #00DA12;
+    width: 5em;
+    text-align: right;
+    float: left;
+    color: #fff;
 }
 
 .editor .nav-sidebar {

--- a/css/editor.css
+++ b/css/editor.css
@@ -6,7 +6,7 @@
     min-height: 300px;
 }
 
-.meta.discussion, .meta.history {
+.meta.discussion, .meta.history, .meta.other-locales {
     padding: 1rem;
 }
 .meta.discussion h6 {

--- a/css/editor.css
+++ b/css/editor.css
@@ -1,4 +1,4 @@
-.editor .meta {
+.editor .nav-sidebar .meta {
     border: 1px solid #ccc;
     margin-left: -1px !important;
     width: 100% !important;

--- a/css/editor.css
+++ b/css/editor.css
@@ -44,6 +44,10 @@
     color: #fff;
 }
 
+.meta.other-locales .sidebar-other-locales {
+    margin: 0.1rem .5rem;
+}
+
 .editor .nav-sidebar {
     float: left;
     width: 35%;
@@ -51,6 +55,9 @@
     padding: 0;
 }
 
+.warning {
+    margin-right: 1rem !important;
+}
 .sidebar-tabs {
     margin: 0;
     padding: 0;

--- a/gp-translation-helpers.php
+++ b/gp-translation-helpers.php
@@ -30,13 +30,15 @@
  */
 
 require_once __DIR__ . '/includes/class-gp-route-translation-helpers.php';
+require_once __DIR__ . '/includes/class-gp-sidebar.php';
 require_once __DIR__ . '/includes/class-gp-translation-helpers.php';
 require_once __DIR__ . '/includes/class-gth-temporary-post.php';
 require_once __DIR__ . '/includes/class-gp-notifications.php';
 require_once __DIR__ . '/includes/class-wporg-notifications.php';
 require_once __DIR__ . '/includes/class-wporg-customizations.php';
 
-add_action( 'gp_init', array( 'GP_Translation_Helpers', 'init' ) );
+add_action( 'gp_init', array( 'GP_Translation_Helpers', 'init' ) ); // todo: remove this when this plugin will be merged in the GlotPress core.
+add_action( 'gp_init', array( 'GP_Sidebar', 'init' ) );    // todo: include this class in a different plugin.
 add_action( 'gp_init', array( 'WPorg_GlotPress_Notifications', 'init' ) );    // todo: include this class in a different plugin.
 add_action( 'gp_init', array( 'WPorg_GlotPress_Customizations', 'init' ) );    // todo: include this class in a different plugin.
 add_filter( 'gp_enable_changesrequested_status', '__return_true' ); // todo: remove this filter when this plugin will be merged in the GlotPress core.

--- a/gp-translation-helpers.php
+++ b/gp-translation-helpers.php
@@ -38,7 +38,7 @@ require_once __DIR__ . '/includes/class-wporg-notifications.php';
 require_once __DIR__ . '/includes/class-wporg-customizations.php';
 
 add_action( 'gp_init', array( 'GP_Translation_Helpers', 'init' ) ); // todo: remove this when this plugin will be merged in the GlotPress core.
-add_action( 'gp_init', array( 'GP_Sidebar', 'init' ) );    // todo: include this class in a different plugin.
+add_action( 'gp_init', array( 'GP_Sidebar', 'init' ) );    // todo: remove this when this plugin will be merged in the GlotPress core.
 add_action( 'gp_init', array( 'WPorg_GlotPress_Notifications', 'init' ) );    // todo: include this class in a different plugin.
 add_action( 'gp_init', array( 'WPorg_GlotPress_Customizations', 'init' ) );    // todo: include this class in a different plugin.
 add_filter( 'gp_enable_changesrequested_status', '__return_true' ); // todo: remove this filter when this plugin will be merged in the GlotPress core.

--- a/includes/class-gp-sidebar.php
+++ b/includes/class-gp-sidebar.php
@@ -14,15 +14,16 @@ class GP_Sidebar {
 	}
 
 	public static function add_tabs( $meta_sidebar, $defined_vars ) {
-		$discussion_tab    = '<div class="meta discussion" id="sidebar-div-discussion-' . $defined_vars['translation']->original_id . '" style="display: none;">Discussion tab</div>';
-		$history_tab       = '<div class="meta history" id="sidebar-div-history-' . $defined_vars['translation']->original_id . '" style="display: none;">History tab</div>';
-		$other_locales_tab = '<div class="meta other-locales" id="sidebar-div-other-locales-' . $defined_vars['translation']->original_id . '" style="display: none;">Other locales tab</div>';
+		$id                = $defined_vars['translation']->row_id;
+		$discussion_tab    = '<div class="meta discussion" id="sidebar-div-discussion-' . $id . '" style="display: none;">Discussion tab</div>';
+		$history_tab       = '<div class="meta history" id="sidebar-div-history-' . $id . '" style="display: none;">History tab</div>';
+		$other_locales_tab = '<div class="meta other-locales" id="sidebar-div-other-locales-' . $id . '" style="display: none;">Other locales tab</div>';
 		$tabs              = '<nav class="nav-sidebar">';
 		$tabs             .= '<ul class="sidebar-tabs">';
-		$tabs             .= '	<li class="current" data-tab="sidebar-tab-meta-' . $defined_vars['translation']->original_id . '">Meta</li>';
-		$tabs             .= '	<li data-tab="sidebar-tab-discussion-' . $defined_vars['translation']->original_id . '">Discuss<span class="count">(5)</span></li>';
-		$tabs             .= '	<li data-tab="sidebar-tab-history-' . $defined_vars['translation']->original_id . '">History<span class="count">(3)</span></li>';
-		$tabs             .= '	<li data-tab="sidebar-tab-other-locales-' . $defined_vars['translation']->original_id . '">Other locales<span class="count">(12)</span></li>';
+		$tabs             .= '	<li class="current" data-tab="sidebar-tab-meta-' . $id . '">Meta</li>';
+		$tabs             .= '	<li data-tab="sidebar-tab-discussion-' . $id . '">Discuss<span class="count">(0)</span></li>';
+		$tabs             .= '	<li data-tab="sidebar-tab-history-' . $id . '">History<span class="count">(0)</span></li>';
+		$tabs             .= '	<li data-tab="sidebar-tab-other-locales-' . $id . '">Other locales<span class="count">(0)</span></li>';
 		$tabs             .= '</ul>';
 
 		$tabs .= $meta_sidebar;

--- a/includes/class-gp-sidebar.php
+++ b/includes/class-gp-sidebar.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Routes: GP_Sidebar class
+ *
+ * Manages the sidebar in the translation rows.
+ *
+ * @package gp-translation-helpers
+ * @since 0.0.2
+ */
+class GP_Sidebar {
+
+	public static function init() {
+		add_filter( 'gp_right_sidebar', array( static::class, 'add_tabs' ), 10, 2 );
+	}
+
+	public static function add_tabs( $meta_sidebar, $defined_vars ) {
+		$tabs  = '<nav class="nav-sidebar">';
+		$tabs .= '<ul class="sidebar-tabs">';
+		$tabs .= '	<li class="current" data-tab="sidebar-tab-meta-' . $defined_vars['translation']->original_id . '">Meta</li>';
+		$tabs .= '	<li data-tab="sidebar-tab-discuss-' . $defined_vars['translation']->original_id . '">Discuss<span class="count">(5)</span></li>';
+		$tabs .= '	<li data-tab="sidebar-tab-history-' . $defined_vars['translation']->original_id . '">History<span class="count">(3)</span></li>';
+		$tabs .= '	<li data-tab="sidebar-tab-other-locales-' . $defined_vars['translation']->original_id . '">Other locales<span class="count">(12)</span></li>';
+		$tabs .= '</ul>';
+
+		$tabs .= $meta_sidebar;
+		$tabs .= '</nav>';
+
+		return $tabs;
+	}
+
+}

--- a/includes/class-gp-sidebar.php
+++ b/includes/class-gp-sidebar.php
@@ -14,15 +14,21 @@ class GP_Sidebar {
 	}
 
 	public static function add_tabs( $meta_sidebar, $defined_vars ) {
-		$tabs  = '<nav class="nav-sidebar">';
-		$tabs .= '<ul class="sidebar-tabs">';
-		$tabs .= '	<li class="current" data-tab="sidebar-tab-meta-' . $defined_vars['translation']->original_id . '">Meta</li>';
-		$tabs .= '	<li data-tab="sidebar-tab-discuss-' . $defined_vars['translation']->original_id . '">Discuss<span class="count">(5)</span></li>';
-		$tabs .= '	<li data-tab="sidebar-tab-history-' . $defined_vars['translation']->original_id . '">History<span class="count">(3)</span></li>';
-		$tabs .= '	<li data-tab="sidebar-tab-other-locales-' . $defined_vars['translation']->original_id . '">Other locales<span class="count">(12)</span></li>';
-		$tabs .= '</ul>';
+		$discussion_tab    = '<div class="meta discussion" id="sidebar-div-discussion-' . $defined_vars['translation']->original_id . '" style="display: none;">Discussion tab</div>';
+		$history_tab       = '<div class="meta history" id="sidebar-div-history-' . $defined_vars['translation']->original_id . '" style="display: none;">History tab</div>';
+		$other_locales_tab = '<div class="meta other-locales" id="sidebar-div-other-locales-' . $defined_vars['translation']->original_id . '" style="display: none;">Other locales tab</div>';
+		$tabs              = '<nav class="nav-sidebar">';
+		$tabs             .= '<ul class="sidebar-tabs">';
+		$tabs             .= '	<li class="current" data-tab="sidebar-tab-meta-' . $defined_vars['translation']->original_id . '">Meta</li>';
+		$tabs             .= '	<li data-tab="sidebar-tab-discussion-' . $defined_vars['translation']->original_id . '">Discuss<span class="count">(5)</span></li>';
+		$tabs             .= '	<li data-tab="sidebar-tab-history-' . $defined_vars['translation']->original_id . '">History<span class="count">(3)</span></li>';
+		$tabs             .= '	<li data-tab="sidebar-tab-other-locales-' . $defined_vars['translation']->original_id . '">Other locales<span class="count">(12)</span></li>';
+		$tabs             .= '</ul>';
 
 		$tabs .= $meta_sidebar;
+		$tabs .= $discussion_tab;
+		$tabs .= $history_tab;
+		$tabs .= $other_locales_tab;
 		$tabs .= '</nav>';
 
 		return $tabs;

--- a/includes/class-gp-sidebar.php
+++ b/includes/class-gp-sidebar.php
@@ -13,6 +13,14 @@ class GP_Sidebar {
 		add_filter( 'gp_right_sidebar', array( static::class, 'add_tabs' ), 10, 2 );
 	}
 
+	/**
+	 * Adds a system with 4 tabs and divs to show the information in the right sidebar.
+	 *
+	 * @param string $meta_sidebar The HTML content for the meta sidebar.
+	 * @param array  $defined_vars The defined variables.
+	 *
+	 * @return string
+	 */
 	public static function add_tabs( $meta_sidebar, $defined_vars ) {
 		$id                = $defined_vars['translation']->row_id;
 		$discussion_tab    = '<div class="meta discussion" id="sidebar-div-discussion-' . $id . '"  data-row-id="' . $id . '" style="display: none;">Discussion tab</div>';

--- a/includes/class-gp-sidebar.php
+++ b/includes/class-gp-sidebar.php
@@ -15,15 +15,15 @@ class GP_Sidebar {
 
 	public static function add_tabs( $meta_sidebar, $defined_vars ) {
 		$id                = $defined_vars['translation']->row_id;
-		$discussion_tab    = '<div class="meta discussion" id="sidebar-div-discussion-' . $id . '" style="display: none;">Discussion tab</div>';
-		$history_tab       = '<div class="meta history" id="sidebar-div-history-' . $id . '" style="display: none;">History tab</div>';
-		$other_locales_tab = '<div class="meta other-locales" id="sidebar-div-other-locales-' . $id . '" style="display: none;">Other locales tab</div>';
+		$discussion_tab    = '<div class="meta discussion" id="sidebar-div-discussion-' . $id . '"  data-row-id="' . $id . '" style="display: none;">Discussion tab</div>';
+		$history_tab       = '<div class="meta history" id="sidebar-div-history-' . $id . '"  data-row-id="' . $id . '" style="display: none;">History tab</div>';
+		$other_locales_tab = '<div class="meta other-locales" id="sidebar-div-other-locales-' . $id . '"  data-row-id="' . $id . '" style="display: none;">Other locales tab</div>';
 		$tabs              = '<nav class="nav-sidebar">';
 		$tabs             .= '<ul class="sidebar-tabs">';
-		$tabs             .= '	<li class="current" data-tab="sidebar-tab-meta-' . $id . '">Meta</li>';
-		$tabs             .= '	<li data-tab="sidebar-tab-discussion-' . $id . '">Discuss<span class="count">(0)</span></li>';
-		$tabs             .= '	<li data-tab="sidebar-tab-history-' . $id . '">History<span class="count">(0)</span></li>';
-		$tabs             .= '	<li data-tab="sidebar-tab-other-locales-' . $id . '">Other locales<span class="count">(0)</span></li>';
+		$tabs             .= '	<li class="current tab-meta" data-tab="sidebar-tab-meta-' . $id . '" data-row-id="' . $id . '">Meta</li>';
+		$tabs             .= '	<li class="tab-discussion" data-tab="sidebar-tab-discussion-' . $id . '" data-row-id="' . $id . '">Discuss<span class="count">(0)</span></li>';
+		$tabs             .= '	<li class="tab-history" data-tab="sidebar-tab-history-' . $id . '" data-row-id="' . $id . '">History<span class="count">(0)</span></li>';
+		$tabs             .= '	<li class="tab-other-locales" data-tab="sidebar-tab-other-locales-' . $id . '" data-row-id="' . $id . '">Other locales<span class="count">(0)</span></li>';
 		$tabs             .= '</ul>';
 
 		$tabs .= $meta_sidebar;

--- a/includes/class-gp-sidebar.php
+++ b/includes/class-gp-sidebar.php
@@ -29,7 +29,7 @@ class GP_Sidebar {
 		$tabs              = '<nav class="nav-sidebar">';
 		$tabs             .= '<ul class="sidebar-tabs">';
 		$tabs             .= '	<li class="current tab-meta" data-tab="sidebar-tab-meta-' . $id . '" data-row-id="' . $id . '">Meta</li>';
-		$tabs             .= '	<li class="tab-discussion" data-tab="sidebar-tab-discussion-' . $id . '" data-row-id="' . $id . '">Discuss<span class="count">(0)</span></li>';
+		$tabs             .= '	<li class="tab-discussion" data-tab="sidebar-tab-discussion-' . $id . '" data-row-id="' . $id . '">Discussion<span class="count">(0)</span></li>';
 		$tabs             .= '	<li class="tab-history" data-tab="sidebar-tab-history-' . $id . '" data-row-id="' . $id . '">History<span class="count">(0)</span></li>';
 		$tabs             .= '	<li class="tab-other-locales" data-tab="sidebar-tab-other-locales-' . $id . '" data-row-id="' . $id . '">Other locales<span class="count">(0)</span></li>';
 		$tabs             .= '</ul>';

--- a/includes/class-gp-translation-helpers.php
+++ b/includes/class-gp-translation-helpers.php
@@ -425,6 +425,15 @@ class GP_Translation_Helpers {
 				'cancel_reply_text'      => esc_html__( 'Cancel reply' ),
 			)
 		);
+		wp_localize_script(
+			'gp-translation-helpers-editor',
+			'wpApiSettings',
+			array(
+				'root'           => esc_url_raw( rest_url() ),
+				'nonce'          => wp_create_nonce( 'wp_rest' ),
+				'admin_ajax_url' => admin_url( 'admin-ajax.php' ),
+			)
+		);
 	}
 
 	/**

--- a/includes/class-gp-translation-helpers.php
+++ b/includes/class-gp-translation-helpers.php
@@ -421,6 +421,8 @@ class GP_Translation_Helpers {
 			'$gp_translation_helpers_editor',
 			array(
 				'translation_helper_url' => gp_url_project( $translation_set['project']->path, gp_url_join( $translation_set['locale_slug'], $translation_set['translation_set']->slug, '-get-translation-helpers' ) ),
+				'reply_text'             => esc_attr__( 'Reply' ),
+				'cancel_reply_text'      => esc_html__( 'Cancel reply' ),
 			)
 		);
 	}

--- a/includes/class-gp-translation-helpers.php
+++ b/includes/class-gp-translation-helpers.php
@@ -378,7 +378,7 @@ class GP_Translation_Helpers {
 	 * @since 0.0.2
 	 *
 	 *  @param string $template Template of the current page.
-	 *  @param string $translation_set Current translation set
+	 *  @param array  $translation_set Current translation set.
 	 *
 	 * @return void
 	 */
@@ -415,6 +415,14 @@ class GP_Translation_Helpers {
 			true
 		);
 		gp_enqueue_scripts( array( 'gp-translation-helpers-editor' ) );
+
+		wp_localize_script(
+			'gp-translation-helpers-editor',
+			'$gp_translation_helpers_editor',
+			array(
+				'translation_helper_url' => gp_url_project( $translation_set['project']->path, gp_url_join( $translation_set['locale_slug'], $translation_set['translation_set']->slug, '-get-translation-helpers' ) ),
+			)
+		);
 	}
 
 	/**

--- a/includes/class-gp-translation-helpers.php
+++ b/includes/class-gp-translation-helpers.php
@@ -75,6 +75,14 @@ class GP_Translation_Helpers {
 		);
 		gp_enqueue_style( 'gp-discussion-css' );
 
+		wp_register_style(  // todo: these CSS should be integrated in GlotPress.
+			'gp-translation-helpers-editor',
+			plugins_url( 'css/editor.css', __DIR__ ),
+			array(),
+			filemtime( plugin_dir_path( __DIR__ ) . 'css/editor.css' )
+		);
+		gp_enqueue_style( 'gp-translation-helpers-editor' );
+
 		add_filter( 'gp_translation_row_template_more_links', array( $this, 'translation_row_template_more_links' ), 10, 5 );
 		add_filter( 'preprocess_comment', array( $this, 'preprocess_comment' ) );
 		add_filter(
@@ -398,6 +406,15 @@ class GP_Translation_Helpers {
 				'comment_reasons' => Helper_Translation_Discussion::get_comment_reasons(),
 			)
 		);
+
+		wp_register_script(
+			'gp-translation-helpers-editor',
+			plugins_url( 'js/editor.js', __DIR__ ),
+			array( 'gp-editor' ),
+			filemtime( plugin_dir_path( __DIR__ ) . 'js/editor.js' ),
+			true
+		);
+		gp_enqueue_scripts( array( 'gp-translation-helpers-editor' ) );
 	}
 
 	/**

--- a/js/editor.js
+++ b/js/editor.js
@@ -14,17 +14,13 @@ jQuery( function( $ ) {
 	// When a new translation row is opened (with double click), the tabs
 	// (header tab and content) for this row are updated with the Ajax query.
 	$gp.editor.table.on( 'dblclick', 'tr.preview td', function() {
-		var originalId = $( this ).parent().attr( 'id' ).substring( 8 );
-		var requestUrl = $gp_translation_helpers_editor.translation_helper_url + originalId + '?nohc';
-		$.getJSON( requestUrl, function( data ) {
-			$( '[data-tab="sidebar-tab-discussion-' + originalId + '"]' ).html( 'Discuss(' + data[ 'helper-translation-discussion-' + originalId ].count + ')' );
-			$( '#sidebar-div-discussion-' + originalId ).html( data[ 'helper-translation-discussion-' + originalId ].content );
-			$( '[data-tab="sidebar-tab-history-' + originalId + '"]' ).html( 'History(' + data[ 'helper-history-' + originalId ].count + ')' );
-			$( '#sidebar-div-history-' + originalId ).html( data[ 'helper-history-' + originalId ].content );
-			$( '[data-tab="sidebar-tab-other-locales-' + originalId + '"]' ).html( 'Other locales(' + data[ 'helper-other-locales-' + originalId ].count + ')' );
-			$( '#sidebar-div-other-locales-' + originalId ).html( data[ 'helper-other-locales-' + originalId ].content );
-			add_copy_button( '#sidebar-div-other-locales-' + originalId );
-		} );
+		loadTabsAndDivs( $( this ) );
+	} );
+
+	// When a new translation row is opened (clicking in the "Details" button), the
+	// tabs (header tab and content) for this row are updated with the Ajax query.
+	$gp.editor.table.on( 'click', '.action.edit', function( ) {
+		loadTabsAndDivs( $( this ) );
 	} );
 
 	// Shows/hides the reply form for a comment in the discussion.
@@ -197,6 +193,25 @@ jQuery( function( $ ) {
 			var html = $( this ).html();
 			html += '<button class="sidebar-other-locales"> Copy </button>';
 			$( this ).html( html );
+		} );
+	}
+
+	/**
+	 * Load the content in the tabs (header tab and content) for the opened row.
+	 *
+	 * @param {Object} element The element that triggers the action.
+	 */
+	function loadTabsAndDivs( element ) {
+		var originalId = element.closest( 'tr' ).attr( 'id' ).substring( 8 );
+		var requestUrl = $gp_translation_helpers_editor.translation_helper_url + originalId + '?nohc';
+		$.getJSON( requestUrl, function( data ) {
+			$( '[data-tab="sidebar-tab-discussion-' + originalId + '"]' ).html( 'Discuss(' + data[ 'helper-translation-discussion-' + originalId ].count + ')' );
+			$( '#sidebar-div-discussion-' + originalId ).html( data[ 'helper-translation-discussion-' + originalId ].content );
+			$( '[data-tab="sidebar-tab-history-' + originalId + '"]' ).html( 'History(' + data[ 'helper-history-' + originalId ].count + ')' );
+			$( '#sidebar-div-history-' + originalId ).html( data[ 'helper-history-' + originalId ].content );
+			$( '[data-tab="sidebar-tab-other-locales-' + originalId + '"]' ).html( 'Other locales(' + data[ 'helper-other-locales-' + originalId ].count + ')' );
+			$( '#sidebar-div-other-locales-' + originalId ).html( data[ 'helper-other-locales-' + originalId ].content );
+			add_copy_button( '#sidebar-div-other-locales-' + originalId );
 		} );
 	}
 } );

--- a/js/editor.js
+++ b/js/editor.js
@@ -1,13 +1,28 @@
-/* global $gp */
+/* global $gp, $gp_translation_helpers_editor */
 /* eslint camelcase: "off" */
 jQuery( function( $ ) {
 	$gp.editor.table.on( 'click', '.sidebar-tabs li', function() {
 		var tab = $( this );
 		var tabId = tab.attr( 'data-tab' );
 		var divId = tabId.replace( 'tab', 'div' );
-		var originalId = tabId.split( '-' ).pop();
+		var originalId = tabId.replace( /[^\d-]/g, '' ).replace( /^-+/g, '' );
 		change_visible_tab( tab );
 		change_visible_div( divId, originalId );
+	} );
+
+	// When a new translation row is opened (with double click), the tabs (header and content)
+	// for this row are updated with the Ajax query.
+	$gp.editor.table.on( 'dblclick', 'tr.preview td', function() {
+		var originalId = $( this ).parent().attr( 'id' ).substring( 8 );
+		var requestUrl = $gp_translation_helpers_editor.translation_helper_url + originalId + '?nohc';
+		$.getJSON( requestUrl, function( data ) {
+			$( '[data-tab="sidebar-tab-discussion-' + originalId + '"]' ).html( 'Discuss(' + data[ 'helper-translation-discussion-' + originalId ].count + ')' );
+			$( '#sidebar-div-discussion-' + originalId ).html( data[ 'helper-translation-discussion-' + originalId ].content );
+			$( '[data-tab="sidebar-tab-history-' + originalId + '"]' ).html( 'History(' + data[ 'helper-history-' + originalId ].count + ')' );
+			$( '#sidebar-div-history-' + originalId ).html( data[ 'helper-history-' + originalId ].content );
+			$( '[data-tab="sidebar-tab-other-locales-' + originalId + '"]' ).html( 'Other locales(' + data[ 'helper-other-locales-' + originalId ].count + ')' );
+			$( '#sidebar-div-other-locales-' + originalId ).html( data[ 'helper-other-locales-' + originalId ].content );
+		} );
 	} );
 
 	/**

--- a/js/editor.js
+++ b/js/editor.js
@@ -205,7 +205,7 @@ jQuery( function( $ ) {
 		var originalId = element.closest( 'tr' ).attr( 'id' ).substring( 8 );
 		var requestUrl = $gp_translation_helpers_editor.translation_helper_url + originalId + '?nohc';
 		$.getJSON( requestUrl, function( data ) {
-			$( '[data-tab="sidebar-tab-discussion-' + originalId + '"]' ).html( 'Discuss(' + data[ 'helper-translation-discussion-' + originalId ].count + ')' );
+			$( '[data-tab="sidebar-tab-discussion-' + originalId + '"]' ).html( 'Discussion(' + data[ 'helper-translation-discussion-' + originalId ].count + ')' );
 			$( '#sidebar-div-discussion-' + originalId ).html( data[ 'helper-translation-discussion-' + originalId ].content );
 			$( '[data-tab="sidebar-tab-history-' + originalId + '"]' ).html( 'History(' + data[ 'helper-history-' + originalId ].count + ')' );
 			$( '#sidebar-div-history-' + originalId ).html( data[ 'helper-history-' + originalId ].content );

--- a/js/editor.js
+++ b/js/editor.js
@@ -131,7 +131,7 @@ jQuery( function( $ ) {
 		return false;
 	} );
 
-	$gp.editor.table.on( 'click', 'button.sidebar-other-locales', function( e ) {
+	$gp.editor.table.on( 'click', 'button.sidebar-other-locales', function() {
 		var textToCopy = $( this ).closest( 'li' ).find( 'a' ).text();
 		var textareaToPaste = $( this ).closest( '.editor' ).find( 'textarea.foreign-text' );
 		var selectionStart = textareaToPaste.get( 0 ).selectionStart;
@@ -179,7 +179,7 @@ jQuery( function( $ ) {
 	/**
 	 * Adds a button to each translation from another locales.
 	 *
-	 * @param sidebarDiv
+	 * @param {string} sidebarDiv The div where we add the buttons.
 	 */
 	function add_copy_button( sidebarDiv ) {
 		var lis = $( sidebarDiv + ' .other-locales li' );

--- a/js/editor.js
+++ b/js/editor.js
@@ -192,7 +192,8 @@ jQuery( function( $ ) {
 
 	// Fires the double click event in the first row of the table if we only
 	// have a row, because GlotPress opens the first editor if the current
-	// table has only one, so with the double click we load the contend sidebar.
+	// table has only one, so with the double click we load the content sidebar.
+	// eslint-disable-next-line vars-on-top
 	var previewRows = $gp.editor.table.find( 'tr.preview' );
 	if ( 1 === previewRows.length ) {
 		$( 'tr.preview td' ).trigger( 'dblclick' );

--- a/js/editor.js
+++ b/js/editor.js
@@ -189,4 +189,12 @@ jQuery( function( $ ) {
 			$( this ).html( html );
 		} );
 	}
+
+	// Fires the double click event in the first row of the table if we only
+	// have a row, because GlotPress opens the first editor if the current
+	// table has only one, so with the double click we load the contend sidebar.
+	var previewRows = $gp.editor.table.find( 'tr.preview' );
+	if ( 1 === previewRows.length ) {
+		$( 'tr.preview td' ).trigger( 'dblclick' );
+	}
 } );

--- a/js/editor.js
+++ b/js/editor.js
@@ -23,6 +23,7 @@ jQuery( function( $ ) {
 			$( '#sidebar-div-history-' + originalId ).html( data[ 'helper-history-' + originalId ].content );
 			$( '[data-tab="sidebar-tab-other-locales-' + originalId + '"]' ).html( 'Other locales(' + data[ 'helper-other-locales-' + originalId ].count + ')' );
 			$( '#sidebar-div-other-locales-' + originalId ).html( data[ 'helper-other-locales-' + originalId ].content );
+			add_copy_button( '#sidebar-div-other-locales-' + originalId );
 		} );
 	} );
 
@@ -130,8 +131,32 @@ jQuery( function( $ ) {
 		return false;
 	} );
 
+	$gp.editor.table.on( 'click', '.sidebar-other-locales', function( e ) {
+		// console.log( $( this ) );
+		var textToCopy = $( this ).closest( 'li' ).find( 'a' ).text();
+		var textareaToPaste = $( this ).closest( '.editor' ).find( 'textarea.foreign-text' );
+		var selectionStart = textareaToPaste.get( 0 ).selectionStart;
+		var selectionEnd = textareaToPaste.get( 0 ).selectionEnd;
+		var textToCopyLength = textToCopy.length;
+		// console.log( textToCopy );
+		// console.log( textareaToPaste );
+		console.log( 'selectionStart: ' + selectionStart + ' selectionEnd: ' + selectionEnd );
+		textareaToPaste.val( textareaToPaste.val().substring( 0, selectionStart ) +
+			textToCopy +
+			textareaToPaste.val().substring( selectionEnd, textareaToPaste.val().length ) );
+		// textareaToPaste.append( textToCopy );
+		selectionStart += textToCopyLength;
+		selectionEnd += textToCopyLength;
+		if ( selectionEnd > textareaToPaste.val().length ) {
+			selectionEnd = textareaToPaste.val().length;
+		}
+		textareaToPaste.get( 0 ).setSelectionRange( selectionStart, selectionEnd );
+		console.log( 'selectionStart: ' + selectionStart + ' selectionEnd: ' + selectionEnd );
+		console.log( '----' );
+	} );
+
 	/**
-	 * Hide all tabs and show one of them, the last clicked.
+	 * Hides all tabs and show one of them, the last clicked.
 	 *
 	 * @param {Object} tab The selected tab.
 	 */
@@ -145,7 +170,7 @@ jQuery( function( $ ) {
 	}
 
 	/**
-	 * Hide all divs and show one of them, the last clicked.
+	 * Hides all divs and show one of them, the last clicked.
 	 *
 	 * @param {string} tabId      The select tab id.
 	 * @param {number} originalId The id of the original string to translate.
@@ -156,5 +181,19 @@ jQuery( function( $ ) {
 		$( '#sidebar-div-history-' + originalId ).hide();
 		$( '#sidebar-div-other-locales-' + originalId ).hide();
 		$( '#' + tabId ).show();
+	}
+
+	/**
+	 * Adds a button to each translation from another locales.
+	 *
+	 * @param sidebarDiv
+	 */
+	function add_copy_button( sidebarDiv ) {
+		var lis = $( sidebarDiv + ' .other-locales li' );
+		lis.each( function() {
+			var html = $( this ).html();
+			html += '<button class="sidebar-other-locales"> Copy </button>';
+			$( this ).html( html );
+		} );
 	}
 } );

--- a/js/editor.js
+++ b/js/editor.js
@@ -131,6 +131,7 @@ jQuery( function( $ ) {
 		return false;
 	} );
 
+	// Copies the translation from another language to the current translation.
 	$gp.editor.table.on( 'click', 'button.sidebar-other-locales', function() {
 		var textToCopy = $( this ).closest( 'li' ).find( 'a' ).text();
 		var textareaToPaste = $( this ).closest( '.editor' ).find( 'textarea.foreign-text' );
@@ -147,6 +148,15 @@ jQuery( function( $ ) {
 		}
 		textareaToPaste.get( 0 ).setSelectionRange( selectionStart, selectionEnd );
 	} );
+
+	// Fires the double click event in the first row of the table if we only
+	// have a row, because GlotPress opens the first editor if the current
+	// table has only one, so with the double click we load the content sidebar.
+	// eslint-disable-next-line vars-on-top
+	var previewRows = $gp.editor.table.find( 'tr.preview' );
+	if ( 1 === previewRows.length ) {
+		$( 'tr.preview td' ).trigger( 'dblclick' );
+	}
 
 	/**
 	 * Hides all tabs and show one of them, the last clicked.
@@ -188,14 +198,5 @@ jQuery( function( $ ) {
 			html += '<button class="sidebar-other-locales"> Copy </button>';
 			$( this ).html( html );
 		} );
-	}
-
-	// Fires the double click event in the first row of the table if we only
-	// have a row, because GlotPress opens the first editor if the current
-	// table has only one, so with the double click we load the content sidebar.
-	// eslint-disable-next-line vars-on-top
-	var previewRows = $gp.editor.table.find( 'tr.preview' );
-	if ( 1 === previewRows.length ) {
-		$( 'tr.preview td' ).trigger( 'dblclick' );
 	}
 } );

--- a/js/editor.js
+++ b/js/editor.js
@@ -1,0 +1,12 @@
+/* global $gp */
+jQuery( function( $ ) {
+	$gp.editor.table.on( 'click', '.sidebar-tabs li', function() {
+		var tab = $( this );
+		var tabId = tab.attr( 'data-tab' );
+		tab.siblings().removeClass( 'current' );
+		tab.parents( '.sidebar-tabs ' ).find( '.helper' ).removeClass( 'current' );
+
+		tab.addClass( 'current' );
+		$( '#' + tabId ).addClass( 'current' );
+	} );
+} );

--- a/js/editor.js
+++ b/js/editor.js
@@ -25,6 +25,18 @@ jQuery( function( $ ) {
 		} );
 	} );
 
+	$gp.editor.table.on( 'click', 'a.comment-reply-link', function( event ) {
+		var commentId = $( this ).attr( 'data-commentid' );
+		event.preventDefault();
+		$( '#comment-reply-' + commentId ).toggle().find( 'textarea' ).focus();
+		if ( $gp_translation_helpers_editor.reply_text === $( this ).text() ) {
+			$( this ).text( $gp_translation_helpers_editor.cancel_reply_text );
+		} else {
+			$( this ).text( $gp_translation_helpers_editor.reply_text );
+		}
+		return false;
+	} );
+
 	/**
 	 * Hide all tabs and show one of them, the last clicked.
 	 *

--- a/js/editor.js
+++ b/js/editor.js
@@ -131,28 +131,21 @@ jQuery( function( $ ) {
 		return false;
 	} );
 
-	$gp.editor.table.on( 'click', '.sidebar-other-locales', function( e ) {
-		// console.log( $( this ) );
+	$gp.editor.table.on( 'click', 'button.sidebar-other-locales', function( e ) {
 		var textToCopy = $( this ).closest( 'li' ).find( 'a' ).text();
 		var textareaToPaste = $( this ).closest( '.editor' ).find( 'textarea.foreign-text' );
 		var selectionStart = textareaToPaste.get( 0 ).selectionStart;
 		var selectionEnd = textareaToPaste.get( 0 ).selectionEnd;
 		var textToCopyLength = textToCopy.length;
-		// console.log( textToCopy );
-		// console.log( textareaToPaste );
-		console.log( 'selectionStart: ' + selectionStart + ' selectionEnd: ' + selectionEnd );
 		textareaToPaste.val( textareaToPaste.val().substring( 0, selectionStart ) +
 			textToCopy +
 			textareaToPaste.val().substring( selectionEnd, textareaToPaste.val().length ) );
-		// textareaToPaste.append( textToCopy );
 		selectionStart += textToCopyLength;
 		selectionEnd += textToCopyLength;
 		if ( selectionEnd > textareaToPaste.val().length ) {
 			selectionEnd = textareaToPaste.val().length;
 		}
 		textareaToPaste.get( 0 ).setSelectionRange( selectionStart, selectionEnd );
-		console.log( 'selectionStart: ' + selectionStart + ' selectionEnd: ' + selectionEnd );
-		console.log( '----' );
 	} );
 
 	/**

--- a/js/editor.js
+++ b/js/editor.js
@@ -1,12 +1,40 @@
 /* global $gp */
+/* eslint camelcase: "off" */
 jQuery( function( $ ) {
 	$gp.editor.table.on( 'click', '.sidebar-tabs li', function() {
 		var tab = $( this );
 		var tabId = tab.attr( 'data-tab' );
+		var divId = tabId.replace( 'tab', 'div' );
+		var originalId = tabId.split( '-' ).pop();
+		change_visible_tab( tab );
+		change_visible_div( divId, originalId );
+	} );
+
+	/**
+	 * Hide all tabs and show one of them, the last clicked.
+	 *
+	 * @param {Object} tab The selected tab.
+	 */
+	function change_visible_tab( tab ) {
+		var tabId = tab.attr( 'data-tab' );
 		tab.siblings().removeClass( 'current' );
 		tab.parents( '.sidebar-tabs ' ).find( '.helper' ).removeClass( 'current' );
-
 		tab.addClass( 'current' );
+
 		$( '#' + tabId ).addClass( 'current' );
-	} );
+	}
+
+	/**
+	 * Hide all divs and show one of them, the last clicked.
+	 *
+	 * @param {string} tabId      The select tab id.
+	 * @param {number} originalId The id of the original string to translate.
+	 */
+	function change_visible_div( tabId, originalId ) {
+		$( '#sidebar-div-meta-' + originalId ).hide();
+		$( '#sidebar-div-discussion-' + originalId ).hide();
+		$( '#sidebar-div-history-' + originalId ).hide();
+		$( '#sidebar-div-other-locales-' + originalId ).hide();
+		$( '#' + tabId ).show();
+	}
 } );


### PR DESCRIPTION
## Problem

<!--
Please describe what is the status/problem before the PR.
-->
Currently, if you want to see the discussion for the translation, you have to open it in another page. This page has 3 tabs, with the discussions, the history and the "other languages" translation.

Solves https://github.com/GlotPress/gp-translation-helpers/issues/147.

This PR depends on this https://github.com/GlotPress/GlotPress/pull/1531, because it adds a required filter.

## Solution

This PR adds 3 tabs, with the discussions, the history and the "other languages" translation.

![image](https://user-images.githubusercontent.com/1667814/203846141-bec197e6-d6b9-426f-840d-225697768b5f.png)


<!--
Please describe how this PR improves the situation.
-->

## Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

You need to be on the `tabs-sidebar` branch on the https://github.com/GlotPress/GlotPress/pull/1531 PR, because this PR adds a required filter.

Then you can start working with the content on the 4 tabs:
* Meta. You can work as you usually work on the current tab to test the functionality.
* Discuss. You can create new comments and/or reply to the existing ones.
* History. You can check the translation history on this tab.
* Other locales. You can check the translation other locales made to this translation.