### PR TITLE
Fix undefined translation_status notice

### DIFF
--- a/helpers/helper-translation-discussion.php
+++ b/helpers/helper-translation-discussion.php
@@ -898,9 +898,8 @@ function gth_discussion_callback( WP_Comment $comment, array $args, int $depth )
 
 	$is_linking_comment = preg_match( '!^' . home_url( gp_url() ) . '[a-z0-9_/#-]+$!i', $comment->comment_content );
 
-	$comment_locale = get_comment_meta( $comment->comment_ID, 'locale', true );
-	$current_locale = $args['locale_slug'];
-
+	$comment_locale         = get_comment_meta( $comment->comment_ID, 'locale', true );
+	$current_locale         = $args['locale_slug'];
 	$current_translation_id = $args['translation_id'];
 	$comment_translation_id = get_comment_meta( $comment->comment_ID, 'translation_id', true );
 
@@ -960,7 +959,7 @@ function gth_discussion_callback( WP_Comment $comment, array $args, int $depth )
 
 			if ( $comment_reason ) :
 				?>
-				The translation <?php gth_print_translation( $comment_translation_id, $args ); ?> <a href="<?php echo esc_url( $linked_comment ); ?>"><?php esc_html_e( 'is being discussed here' ); ?></a>.
+				<p>The translation <?php gth_print_translation( $comment_translation_id, $args ); ?> <a href="<?php echo esc_url( $linked_comment ); ?>"><?php esc_html_e( 'is being discussed here' ); ?></a>.</p>
 			<?php else : ?>
 				<a href="<?php echo esc_url( $linked_comment ); ?>"><?php esc_html_e( 'Please continue the discussion here' ); ?></a>
 			<?php endif; ?>
@@ -1037,14 +1036,15 @@ function gth_discussion_callback( WP_Comment $comment, array $args, int $depth )
 				<?php
 			}
 
-			if ( ! $is_linking_comment ) :
-				if ( $comment_translation_id && $comment_translation_id !== $current_translation_id ) {
-					$translation_status = '';
-					if ( $_translation_status ) {
-						$translation_status = ' (' . $_translation_status[0] . ')';
-					}
-					gth_print_translation( $comment_translation_id, $args, 'Translation' . $translation_status . ': ' );
+			if ( $comment_translation_id && $comment_translation_id !== $current_translation_id ) {
+				$translation_status = '';
+				if ( $_translation_status ) {
+
+					$translation_status = ( is_array( $_translation_status ) && array_key_exists( $comment_translation_id, $_translation_status ) ) ? '(' . $_translation_status[ $comment_translation_id ] . ')' : ' (' . $_translation_status[0] . ')';
 				}
+				gth_print_translation( $comment_translation_id, $args, 'Translation' . $translation_status . ': ' );
+			}
+			if ( ! $is_linking_comment ) :
 
 				?>
 				<div id="comment-reply-<?php echo esc_attr( $comment->comment_ID ); ?>" style="display: none;">

--- a/helpers/helper-translation-discussion.php
+++ b/helpers/helper-translation-discussion.php
@@ -1041,7 +1041,7 @@ function gth_discussion_callback( WP_Comment $comment, array $args, int $depth )
 				if ( $comment_translation_id && $comment_translation_id !== $current_translation_id ) {
 					$translation_status = '';
 					if ( $_translation_status ) {
-						$translation_status = ' (' . $_translation_status . ')';
+						$translation_status = ' (' . $_translation_status[0] . ')';
 					}
 					gth_print_translation( $comment_translation_id, $args, 'Translation' . $translation_status . ': ' );
 				}

--- a/includes/class-gp-translation-helpers.php
+++ b/includes/class-gp-translation-helpers.php
@@ -412,7 +412,7 @@ class GP_Translation_Helpers {
 
 		$helper_discussion    = new Helper_Translation_Discussion();
 		$locale_slug          = $helper_discussion->sanitize_comment_locale( sanitize_text_field( $_POST['data']['locale_slug'] ) );
-		$translation_status   = $helper_discussion->sanitize_translation_status( sanitize_text_field( $_POST['data']['translation_status'] ) );
+		$translation_status   = ! empty( $_POST['data']['translation_status'] ) ? array_map( array( $helper_discussion, 'sanitize_translation_status' ), $_POST['data']['translation_status'] ) : null;
 		$translation_id_array = ! empty( $_POST['data']['translation_id'] ) ? array_map( array( $helper_discussion, 'sanitize_translation_id' ), $_POST['data']['translation_id'] ) : null;
 		$original_id_array    = ! empty( $_POST['data']['original_id'] ) ? array_map( array( $helper_discussion, 'sanitize_original_id' ), $_POST['data']['original_id'] ) : null;
 		$comment_reason       = ! empty( $_POST['data']['reason'] ) ? $_POST['data']['reason'] : array( 'other' );

--- a/js/reject-feedback.js
+++ b/js/reject-feedback.js
@@ -6,6 +6,8 @@
 			var translationIds = [];
 			var originalIds = [];
 			var bulkTranslationStatus = [];
+			var translationStatuses = {};
+			var statusIndex = 0;
 			var modalFeedbackForm =
 			'<div id="reject-feedback-form" style="display:none;">' +
 			'<form>' +
@@ -50,7 +52,9 @@
 							if ( originalId && translationId ) {
 								originalIds.push( originalId );
 								translationIds.push( translationId );
+								translationStatuses[ translationId ] = bulkTranslationStatus[ statusIndex ];
 							}
+							statusIndex++;
 						}
 					);
 
@@ -109,7 +113,7 @@
 					commentData.original_id = originalIds;
 					commentData.translation_id = translationIds;
 					commentData.is_bulk_reject = true;
-					commentData.translation_status = bulkTranslationStatus;
+					commentData.translation_status = translationStatuses;
 
 					commentWithFeedback( commentData, false, 'rejected' );
 					e.preventDefault();

--- a/js/reject-feedback.js
+++ b/js/reject-feedback.js
@@ -5,6 +5,7 @@
 			var rowIds = [];
 			var translationIds = [];
 			var originalIds = [];
+			var bulkTranslationStatus = [];
 			var modalFeedbackForm =
 			'<div id="reject-feedback-form" style="display:none;">' +
 			'<form>' +
@@ -29,7 +30,11 @@
 					rowIds = $( 'input:checked', $( 'table#translations th.checkbox' ) ).map(
 						function() {
 							var selectedRow = $( this ).parents( 'tr.preview' );
+							var translationStatus = '';
+
 							if ( ! selectedRow.hasClass( 'untranslated' ) ) {
+								translationStatus = selectedRow.attr( 'class' ).split( ' ' )[ 1 ].substring( 7 );
+								bulkTranslationStatus.push( translationStatus );
 								return selectedRow.attr( 'row' );
 							}
 							$( this ).prop( 'checked', false );
@@ -104,6 +109,8 @@
 					commentData.original_id = originalIds;
 					commentData.translation_id = translationIds;
 					commentData.is_bulk_reject = true;
+					commentData.translation_status = bulkTranslationStatus;
+
 					commentWithFeedback( commentData, false, 'rejected' );
 					e.preventDefault();
 				}

--- a/js/reject-feedback.js
+++ b/js/reject-feedback.js
@@ -289,7 +289,7 @@
 		feedbackData.comment = comment;
 		feedbackData.original_id = [ $gp.editor.current.original_id ];
 		feedbackData.translation_id = [ $gp.editor.current.translation_id ];
-		feedbackData.translation_status = status;
+		feedbackData.translation_status = [ status ];
 
 		commentWithFeedback( feedbackData, button, status );
 	}


### PR DESCRIPTION
#### Problem
This notice is thrown quite frequently on translate.wordpress.org 
`E_NOTICE: Undefined index: translation_status in /home/wporg/public_html/wp-content/plugins/gp-translation-helpers/includes/class-gp-translation-helpers.php:415`

It's related to this [line](https://github.com/GlotPress/gp-translation-helpers/blob/06418470d081f03dd78c751d28e76e7dbf958940/includes/class-gp-translation-helpers.php#L415)

This notice is thrown when a bulk `changesrequested` action is done. This is because we don't send the translation status of each rejected translation in the payload for bulk rejection.

#### Solution

We add the translation status for each item in the bulk rejection to the payload before sending it via AJAX.


