### PR TITLE
Fix broken linked comments for bulk rejection

### DIFF
--- a/includes/class-gp-translation-helpers.php
+++ b/includes/class-gp-translation-helpers.php
@@ -450,8 +450,8 @@ class GP_Translation_Helpers {
 			$comment = get_comment_link( $first_comment_id );
 			foreach ( $original_id_array as $index => $single_original_id ) {
 				$comment_id = $this->insert_comment( $comment, $single_original_id, $comment_reason, $translation_id_array[ $index ], $locale_slug, $_SERVER, $translation_status );
-				$comment    = get_comment( $comment_id );
-				GP_Notifications::add_related_comment( $comment );
+				$_comment   = get_comment( $comment_id );
+				GP_Notifications::add_related_comment( $_comment );
 			}
 		}
 


### PR DESCRIPTION
#### Problem

When you do a bulk 'changes requested', the link to the comment which contains the reasons and comments entered during the bulk action is only displayed on the discussions page for the second translation and not for the subsequent ones.

#### Solution

With this PR, only the comment on the discussions page for the first rejected translation displays the full comment, for other rejected translations, a link to the comment for the first translation is displayed.
> Comment for the first rejected translation
<img width="502" alt="image" src="https://user-images.githubusercontent.com/2834132/206145914-15258bb7-b2f4-4f5d-9a30-b2c89b0c137a.png">

> Comment for the second rejected translation
<img width="853" alt="image" src="https://user-images.githubusercontent.com/2834132/206147310-d45b5771-c65b-4820-8e8b-7c409261b04e.png">

#### Testing instructions
1. Select more than 2 translations that you want to reject.
2. Use the bulk actions dropdown and select 'Reject' and click 'Apply'.
3. Choose a few reasons and enter a comment in the popover displayed and click 'Request changes'.
4. Go to the discussions page of each of the translations rejected.
5. A link to the original comment entered for the first rejected item should be displayed.

