### PR TITLE
Add custom reasons for `it` locale

### DIFF
--- a/css/discussion.css
+++ b/css/discussion.css
@@ -203,10 +203,10 @@ div#TB_ajaxWindowTitle {
 }
 .gp-content ul.feedback-reason-list {
 	list-style-type: none;
-    display: grid;
-    grid-template-columns: repeat(2, 1fr);
-    grid-column-gap: 4px;
-    margin-left: 0;
+	display: grid;
+	grid-template-columns: repeat(2, 1fr);
+	grid-column-gap: 4px;
+	margin-left: 0;
 }
 .feedback-reason-list li {
 	float: left;
@@ -222,11 +222,11 @@ div#TB_ajaxWindowTitle {
 }
 .feedback-reason-list li span.gp-reason-text {
 	display: inline-block;
-    margin-bottom: 5px;
-    float: left;
-    width: 70%;
-    margin-left: 2px;
-    margin-top: -8px;
+	margin-bottom: .5em;
+	float: left;
+	width: 70%;
+	margin-left: .5em;
+	margin-top: -0.5em;
 }
 .feedback-comment label, .gp-content h3.feedback-reason-title {
 	font-size: 1.1em;

--- a/css/discussion.css
+++ b/css/discussion.css
@@ -204,8 +204,12 @@ div#TB_ajaxWindowTitle {
 }
 .gp-content ul.feedback-reason-list {
 	list-style-type: none;
-	display: inline-block;
 	padding-left: .5em;
+    display: grid;
+    overflow: hidden;
+    grid-template-columns: repeat(2, 1fr);
+    grid-column-gap: 4px;
+    margin-left: 0;
 }
 .feedback-reason-list li {
 	width: 50%;
@@ -215,9 +219,15 @@ div#TB_ajaxWindowTitle {
 .feedback-reason-list li label {
 	font-size: 1.1em;
 	cursor: pointer;
+	display: inline-block;
 }
 .feedback-reason-list li input[type="checkbox"] {
 	margin-right: 5px;
+	float: left;
+}
+.feedback-reason-list li span.gp-reason-text {
+    display: flex;
+    margin-top: -10px;
 }
 .feedback-comment label, .gp-content h3.feedback-reason-title {
 	font-size: 1.1em;

--- a/css/discussion.css
+++ b/css/discussion.css
@@ -74,7 +74,6 @@ article.comment time {
 	font-size:16px;
 }
 .feedback-reason-list li {
-	white-space:nowrap;
 	padding-right: 2px;
 }
 .ui-tooltip {
@@ -204,30 +203,30 @@ div#TB_ajaxWindowTitle {
 }
 .gp-content ul.feedback-reason-list {
 	list-style-type: none;
-	padding-left: .5em;
     display: grid;
-    overflow: hidden;
     grid-template-columns: repeat(2, 1fr);
     grid-column-gap: 4px;
     margin-left: 0;
 }
 .feedback-reason-list li {
-	width: 50%;
 	float: left;
 	padding-top: 4px;
 }
 .feedback-reason-list li label {
 	font-size: 1.1em;
 	cursor: pointer;
-	display: inline-block;
+	min-width: 100%;
 }
 .feedback-reason-list li input[type="checkbox"] {
-	margin-right: 5px;
 	float: left;
 }
 .feedback-reason-list li span.gp-reason-text {
-    display: flex;
-    margin-top: -10px;
+	display: inline-block;
+    margin-bottom: 5px;
+    float: left;
+    width: 70%;
+    margin-left: 2px;
+    margin-top: -8px;
 }
 .feedback-comment label, .gp-content h3.feedback-reason-title {
 	font-size: 1.1em;

--- a/helpers/helper-translation-discussion.php
+++ b/helpers/helper-translation-discussion.php
@@ -971,7 +971,7 @@ function gth_discussion_callback( WP_Comment $comment, array $args, int $depth )
 				<?php
 				$number_of_items = count( $comment_reason );
 				$counter         = 0;
-				$comment_reasons = Helper_Translation_Discussion::get_comment_reasons();
+				$comment_reasons = Helper_Translation_Discussion::get_comment_reasons( $comment_locale );
 				foreach ( $comment_reason as $reason ) {
 					echo wp_kses(
 						sprintf(

--- a/includes/class-gp-custom-locale-reasons.php
+++ b/includes/class-gp-custom-locale-reasons.php
@@ -22,34 +22,7 @@ class GP_Custom_Locale_Reasons extends GP_Route {
 		// ),
 		// )
 		// );
-		$locale_reasons = array(
-			'it' => array(
-				'consistency'          => array(
-					'name'        => 'Consistenza',
-					'explanation' => 'Utilizzare una traduzione consistente',
-				),
-				'second_person'        => array(
-					'name'        => '2a persona',
-					'explanation' => 'Per i verbi utilizziamo la seconda persona singolare rivolgendoci direttamente all’utente',
-				),
-				'capitalize_titlecase' => array(
-					'name'        => 'No maiuscole TitleCase',
-					'explanation' => 'Verificare il corretto uso delle maiuscole in italiano, sono presenti maiuscole non necessarie/errate',
-				),
-				'double_space'         => array(
-					'name'        => 'Spazio doppio',
-					'explanation' => 'Sono presenti uno o più uno spazi doppi',
-				),
-				'beginning_space'      => array(
-					'name'        => 'Spazio all’inizio o alla fine',
-					'explanation' => 'Sono presenti/assenti spazi all’inizio o alla fine della traduzione diversamente dalla stringa originale',
-				),
-				'no_s_plural'          => array(
-					'name'        => 'Niente s al plurale',
-					'explanation' => 'In italiano non si riportano le s del plurale dei termini che rimangono invariati',
-				),
-			),
-		);
+		$locale_reasons = array();
 
 		return isset( $locale_reasons[ $locale ] ) ? $locale_reasons[ $locale ] : array();
 	}

--- a/includes/class-gp-custom-locale-reasons.php
+++ b/includes/class-gp-custom-locale-reasons.php
@@ -22,7 +22,34 @@ class GP_Custom_Locale_Reasons extends GP_Route {
 		// ),
 		// )
 		// );
-		$locale_reasons = array();
+		$locale_reasons = array(
+			'it' => array(
+				'Consistenza'                   => array(
+					'name'        => __( 'Consistenza' ),
+					'explanation' => __( 'Utilizzare una traduzione consistente' ),
+				),
+				'2a persona'                    => array(
+					'name'        => __( '2a persona' ),
+					'explanation' => __( 'Per i verbi utilizziamo la seconda persona singolare rivolgendoci direttamente all’utente' ),
+				),
+				'No maiuscole TitleCase'        => array(
+					'name'        => __( 'No maiuscole TitleCase' ),
+					'explanation' => __( 'Verificare il corretto uso delle maiuscole in italiano, sono presenti maiuscole non necessarie/errate' ),
+				),
+				'Spazio doppio'                 => array(
+					'name'        => __( 'Spazio doppio' ),
+					'explanation' => __( 'Sono presenti uno o più uno spazi doppi' ),
+				),
+				'Spazio all’inizio o alla fine' => array(
+					'name'        => __( 'Spazio all’inizio o alla fine' ),
+					'explanation' => __( 'Sono presenti/assenti spazi all’inizio o alla fine della traduzione diversamente dalla stringa originale' ),
+				),
+				'Niente s al plurale'           => array(
+					'name'        => __( 'Niente s al plurale' ),
+					'explanation' => __( 'In italiano non si riportano le s del plurale dei termini che rimangono invariati' ),
+				),
+			),
+		);
 
 		return isset( $locale_reasons[ $locale ] ) ? $locale_reasons[ $locale ] : array();
 	}

--- a/includes/class-gp-custom-locale-reasons.php
+++ b/includes/class-gp-custom-locale-reasons.php
@@ -24,29 +24,29 @@ class GP_Custom_Locale_Reasons extends GP_Route {
 		// );
 		$locale_reasons = array(
 			'it' => array(
-				'Consistenza'                   => array(
-					'name'        => __( 'Consistenza' ),
-					'explanation' => __( 'Utilizzare una traduzione consistente' ),
+				'consistency'          => array(
+					'name'        => 'Consistenza',
+					'explanation' => 'Utilizzare una traduzione consistente',
 				),
-				'2a persona'                    => array(
-					'name'        => __( '2a persona' ),
-					'explanation' => __( 'Per i verbi utilizziamo la seconda persona singolare rivolgendoci direttamente all’utente' ),
+				'second_person'        => array(
+					'name'        => '2a persona',
+					'explanation' => 'Per i verbi utilizziamo la seconda persona singolare rivolgendoci direttamente all’utente',
 				),
-				'No maiuscole TitleCase'        => array(
-					'name'        => __( 'No maiuscole TitleCase' ),
-					'explanation' => __( 'Verificare il corretto uso delle maiuscole in italiano, sono presenti maiuscole non necessarie/errate' ),
+				'capitalize_titlecase' => array(
+					'name'        => 'No maiuscole TitleCase',
+					'explanation' => 'Verificare il corretto uso delle maiuscole in italiano, sono presenti maiuscole non necessarie/errate',
 				),
-				'Spazio doppio'                 => array(
-					'name'        => __( 'Spazio doppio' ),
-					'explanation' => __( 'Sono presenti uno o più uno spazi doppi' ),
+				'double_space'         => array(
+					'name'        => 'Spazio doppio',
+					'explanation' => 'Sono presenti uno o più uno spazi doppi',
 				),
-				'Spazio all’inizio o alla fine' => array(
-					'name'        => __( 'Spazio all’inizio o alla fine' ),
-					'explanation' => __( 'Sono presenti/assenti spazi all’inizio o alla fine della traduzione diversamente dalla stringa originale' ),
+				'beginning_space'      => array(
+					'name'        => 'Spazio all’inizio o alla fine',
+					'explanation' => 'Sono presenti/assenti spazi all’inizio o alla fine della traduzione diversamente dalla stringa originale',
 				),
-				'Niente s al plurale'           => array(
-					'name'        => __( 'Niente s al plurale' ),
-					'explanation' => __( 'In italiano non si riportano le s del plurale dei termini che rimangono invariati' ),
+				'no_s_plural'          => array(
+					'name'        => 'Niente s al plurale',
+					'explanation' => 'In italiano non si riportano le s del plurale dei termini che rimangono invariati',
 				),
 			),
 		);

--- a/includes/class-gp-translation-helpers.php
+++ b/includes/class-gp-translation-helpers.php
@@ -452,7 +452,7 @@ class GP_Translation_Helpers {
 		$translation_id_array = ! empty( $_POST['data']['translation_id'] ) ? array_map( array( $helper_discussion, 'sanitize_translation_id' ), $_POST['data']['translation_id'] ) : null;
 		$original_id_array    = ! empty( $_POST['data']['original_id'] ) ? array_map( array( $helper_discussion, 'sanitize_original_id' ), $_POST['data']['original_id'] ) : null;
 		$comment_reason       = ! empty( $_POST['data']['reason'] ) ? $_POST['data']['reason'] : array( 'other' );
-		$all_comment_reasons  = array_keys( Helper_Translation_Discussion::get_comment_reasons() );
+		$all_comment_reasons  = array_keys( Helper_Translation_Discussion::get_comment_reasons( $locale_slug ) );
 		$comment_reason       = array_filter(
 			$comment_reason,
 			function( $reason ) use ( $all_comment_reasons ) {

--- a/js/reject-feedback.js
+++ b/js/reject-feedback.js
@@ -355,7 +355,7 @@
 			prefix = '<div class="modal-item"><label class="tooltip" title="' + commentReasons[ reason ].explanation + '">';
 			suffix = '</label> <span class="tooltip dashicons dashicons-info" title="' + commentReasons[ reason ].explanation + '"></span></div>';
 			inputName = 'modal_feedback_reason';
-			commentList += prefix + '<input type="checkbox" name="' + inputName + '" value="' + reason + '" /> ' + commentReasons[ reason ].name + suffix;
+			commentList += prefix + '<input type="checkbox" name="' + inputName + '" value="' + reason + '" /> <span class="gp-reason-text">' + commentReasons[ reason ].name + '</span>' + suffix;
 		}
 		return commentList;
 	}

--- a/js/reject-feedback.js
+++ b/js/reject-feedback.js
@@ -353,7 +353,7 @@
 		// eslint-disable-next-line vars-on-top
 		for ( var reason in commentReasons ) {
 			prefix = '<div class="modal-item"><label class="tooltip" title="' + commentReasons[ reason ].explanation + '">';
-			suffix = '</label> <span class="tooltip dashicons dashicons-info" title="' + commentReasons[ reason ].explanation + '"></span></div>';
+			suffix = '<span class="tooltip dashicons dashicons-info" title="' + commentReasons[ reason ].explanation + '"></span></label></div>';
 			inputName = 'modal_feedback_reason';
 			commentList += prefix + '<input type="checkbox" name="' + inputName + '" value="' + reason + '" /> <span class="gp-reason-text">' + commentReasons[ reason ].name + '</span>' + suffix;
 		}

--- a/js/reject-feedback.js
+++ b/js/reject-feedback.js
@@ -352,7 +352,7 @@
 
 		// eslint-disable-next-line vars-on-top
 		for ( var reason in commentReasons ) {
-			prefix = '<div class="modal-item"><label class="tooltip" title="' + commentReasons[ reason ].explanation + '">';
+			prefix = '<div class="modal-item"><label>';
 			suffix = '<span class="tooltip dashicons dashicons-info" title="' + commentReasons[ reason ].explanation + '"></span></label></div>';
 			inputName = 'modal_feedback_reason';
 			commentList += prefix + '<input type="checkbox" name="' + inputName + '" value="' + reason + '" /> <span class="gp-reason-text">' + commentReasons[ reason ].name + '</span>' + suffix;

--- a/templates/translation-row-editor-meta-feedback.php
+++ b/templates/translation-row-editor-meta-feedback.php
@@ -12,7 +12,7 @@
 			foreach ( $comment_reasons as $key => $reason ) :
 				?>
 					<li>
-						<label class="tooltip" title="<?php echo esc_attr( $reason['explanation'] ); ?>"><input type="checkbox" name="feedback_reason" value="<?php echo esc_attr( $key ); ?>" /><span class="gp-reason-text"><?php echo esc_html( $reason['name'] ); ?></span></label><span class="tooltip dashicons dashicons-info" title="<?php echo esc_attr( $reason['explanation'] ); ?>"></span>
+						<label class="tooltip" title="<?php echo esc_attr( $reason['explanation'] ); ?>"><input type="checkbox" name="feedback_reason" value="<?php echo esc_attr( $key ); ?>" /><span class="gp-reason-text"><?php echo esc_html( $reason['name'] ); ?></span><span class="tooltip dashicons dashicons-info" title="<?php echo esc_attr( $reason['explanation'] ); ?>"></span></label>
 					</li>
 				<?php endforeach; ?>
 			</ul>

--- a/templates/translation-row-editor-meta-feedback.php
+++ b/templates/translation-row-editor-meta-feedback.php
@@ -12,7 +12,7 @@
 			foreach ( $comment_reasons as $key => $reason ) :
 				?>
 					<li>
-						<label class="tooltip" title="<?php echo esc_attr( $reason['explanation'] ); ?>"><input type="checkbox" name="feedback_reason" value="<?php echo esc_attr( $key ); ?>" /><span class="gp-reason-text"><?php echo esc_html( $reason['name'] ); ?></span><span class="tooltip dashicons dashicons-info" title="<?php echo esc_attr( $reason['explanation'] ); ?>"></span></label>
+						<label><input type="checkbox" name="feedback_reason" value="<?php echo esc_attr( $key ); ?>" /><span class="gp-reason-text"><?php echo esc_html( $reason['name'] ); ?></span><span class="tooltip dashicons dashicons-info" title="<?php echo esc_attr( $reason['explanation'] ); ?>"></span></label>
 					</li>
 				<?php endforeach; ?>
 			</ul>

--- a/templates/translation-row-editor-meta-feedback.php
+++ b/templates/translation-row-editor-meta-feedback.php
@@ -12,7 +12,7 @@
 			foreach ( $comment_reasons as $key => $reason ) :
 				?>
 					<li>
-						<label class="tooltip" title="<?php echo esc_attr( $reason['explanation'] ); ?>"><input type="checkbox" name="feedback_reason" value="<?php echo esc_attr( $key ); ?>" /><?php echo esc_html( $reason['name'] ); ?></label><span class="tooltip dashicons dashicons-info" title="<?php echo esc_attr( $reason['explanation'] ); ?>"></span>
+						<label class="tooltip" title="<?php echo esc_attr( $reason['explanation'] ); ?>"><input type="checkbox" name="feedback_reason" value="<?php echo esc_attr( $key ); ?>" /><span class="gp-reason-text"><?php echo esc_html( $reason['name'] ); ?></span></label><span class="tooltip dashicons dashicons-info" title="<?php echo esc_attr( $reason['explanation'] ); ?>"></span>
 					</li>
 				<?php endforeach; ?>
 			</ul>


### PR DESCRIPTION
#### Problem

Custom reasons have been requested for the `it` locale [here](https://make.wordpress.org/polyglots/2023/02/16/feedback-tool-custom-reasons-for-it_it/) 

#### Solution

In this PR we have added the custom reasons. However we noticed that the because some of the custom reasons had long texts, it distorted the view as shown below;
> Before
<img width="371" alt="image" src="https://user-images.githubusercontent.com/2834132/221294950-47d02716-7d6f-4bb9-ac1a-fcb4946100da.png">

> After 
![image](https://user-images.githubusercontent.com/2834132/221625150-d82526f6-1c07-44a0-b259-72fe2a85d799.png)


In this PR, we have also ensured that the custom reasons are nicely wrapped and properly displayed.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

