### PR TITLE
Fix three constant PHP Notices.

### DIFF
--- a/helpers/helper-translation-discussion.php
+++ b/helpers/helper-translation-discussion.php
@@ -579,7 +579,7 @@ class Helper_Translation_Discussion extends GP_Translation_Helper {
 				'post'                 => $post,
 				'translation_id'       => isset( $this->data['translation_id'] ) ? $this->data['translation_id'] : null,
 				'locale_slug'          => $this->data['locale_slug'],
-				'original_permalink'   => $this->data['original_permalink'],
+				'original_permalink'   => $this->data['original_permalink'] ?? false,
 				'original_id'          => $this->data['original_id'],
 				'project'              => $this->data['project'],
 				'translation_set_slug' => $this->data['translation_set_slug'],

--- a/includes/class-wporg-notifications.php
+++ b/includes/class-wporg-notifications.php
@@ -147,7 +147,8 @@ class WPorg_GlotPress_Notifications {
 								$role  = ! ( 'commenter' === $mentionable_user['role'] ) ? ' - ' . $mentionable_user['role'] : '';
 							}
 
-								$user = get_user_by( 'email', $email );
+							$user = get_user_by( 'email', $email );
+							if ( $user ) {
 								return array(
 									'ID'            => $user->ID,
 									'user_login'    => $user->user_login,
@@ -156,10 +157,16 @@ class WPorg_GlotPress_Notifications {
 									'source'        => array( 'translators' ),
 									'image_URL'     => get_avatar_url( $user->ID ),
 								);
+							}
+
+							return false;
 						},
 						$all_email_addresses
 					);
-							return $users;
+
+					$users = array_filter( $users );
+
+					return $users;
 				},
 				10,
 				4


### PR DESCRIPTION
E_NOTICE: Undefined index: original_permalink in wp-content/plugins/gp-translation-helpers/helpers/helper-translation-discussion.php:582
E_NOTICE: Trying to get property 'ID' of non-object in wp-content/plugins/gp-translation-helpers/includes/class-wporg-notifications.php:157
E_NOTICE: Trying to get property 'user_nicename' of non-object in wp-content/plugins/gp-translation-helpers/includes/class-wporg-notifications.php:154

#### Problem

<!--
Please describe what is the status/problem before the PR.
-->

These PHP Notices have been constantly being hit on WordPress.org.

#### Solution

This is not a fix. This is a bandaid (mostly).
This is deployed to WordPress.org.

<!--
Please describe how this PR improves the situation.
-->

#### Testing instructions

No testing has been done.

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

