### PR TITLE
Check if the row selectedRow has length, to avoid the first one in a bulk selection

### DIFF
--- a/js/reject-feedback.js
+++ b/js/reject-feedback.js
@@ -34,7 +34,7 @@
 							var selectedRow = $( this ).parents( 'tr.preview' );
 							var translationStatus = '';
 
-							if ( ! selectedRow.hasClass( 'untranslated' ) ) {
+							if ( ( selectedRow.length ) && ( ! selectedRow.hasClass( 'untranslated' ) ) ) {
 								translationStatus = selectedRow.attr( 'class' ).split( ' ' )[ 1 ].substring( 7 );
 								bulkTranslationStatus.push( translationStatus );
 								return selectedRow.attr( 'row' );


### PR DESCRIPTION
## Problem

<!--
Please describe what is the status/problem before the PR.
-->

When a user makes a multiple selection with the checkbox at the top of the table, and then she made a bulk rejection, the "Reject with Feedback" form was not shown: all the translations are rejected.

![image](https://user-images.githubusercontent.com/1667814/222111856-f7a3f0a0-eb28-4e4f-87e7-0619c48d625e.png)

The problem is happening with this header checkbox, when we try to get the `translationStatus`, because it fires an exception.

```
if ( ( ! selectedRow.hasClass( 'untranslated' ) ) ) {
	translationStatus = selectedRow.attr( 'class' ).split( ' ' )[ 1 ].substring( 7 );
	bulkTranslationStatus.push( translationStatus );
	return selectedRow.attr( 'row' );
}
```

## Solution

The solution is to check the `selectRow` length, to be sure the `selectedRow` exists.

<!--
Please describe how this PR improves the situation.
-->

## Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Apply the PR.
2. Select all the translations in the translation table.
3. You will see the "Reject with Feedback" form in a popup.