### PR TITLE
Fix caching bug in translate.wordpress.org production

### DIFF
--- a/helpers/helper-translation-discussion.php
+++ b/helpers/helper-translation-discussion.php
@@ -440,7 +440,7 @@ class Helper_Translation_Discussion extends GP_Translation_Helper {
 		if ( false !== $post_id ) {
 			// Something was found in the cache.
 
-			if ( self::is_temporary_post_id( $post_id ) && $create ) {
+			if ( self::is_temporary_post_id( $post_id ) ) {
 				// a fake post_id was stored in the cache but we need to create an entry.
 				// Let's pretend a cache fail, so that we get a chance to create an entry unless one already exists.
 				$post_id = false;
@@ -484,7 +484,7 @@ class Helper_Translation_Discussion extends GP_Translation_Helper {
 			}
 		}
 
-		wp_cache_add( $cache_key, $post_id );
+		wp_cache_set( $cache_key, $post_id );
 		return $post_id;
 	}
 


### PR DESCRIPTION
#### Problem
Comments are invisible because the post cannot be found after a temporary post id has been cached. The cache is not updated because `wp_cache_add()` was used which doesn't overwrite cache entries.

#### Solution

Use `wp_cache_set()` and remove that the cache fail workaround is only active when the page needs to be created.

#### Testing instructions
This is hard to test since it relies on a cache that has the wrong value in production.

Fixes #165.