### PR TITLE
Remove the escape for the ul and li items in the history tab

### DIFF
--- a/css/translation-helpers.css
+++ b/css/translation-helpers.css
@@ -83,6 +83,13 @@ ul.helpers-tabs {
 	border: 1px solid rgb(0 0 0 / 5%);
 }
 
+#translation-history-table ul {
+	margin-left: -1rem;
+}
+#translation-history-table li:not(:last-child){
+	margin-bottom: 0.5rem;
+}
+
 footer em {
 	margin-left: 14px;
 }

--- a/helpers/helper-translation-history.php
+++ b/helpers/helper-translation-history.php
@@ -121,7 +121,7 @@ class Helper_History extends GP_Translation_Helper {
 				is_null( $translation->translation_4 ) &&
 				is_null( $translation->translation_5 )
 			) {
-					$output_translation = $translation->translation_0;
+					$output_translation = esc_translation( $translation->translation_0 );
 			} else {
 				$output_translation = '<ul>';
 				for ( $i = 0; $i <= 5; $i ++ ) {
@@ -137,7 +137,8 @@ class Helper_History extends GP_Translation_Helper {
 				esc_attr( $translation->status ),
 				esc_attr( $translation->date_modified ?? $translation->date_added ),
 				esc_html( $date_and_time[0] ),
-				$translation_permalink ? '<a href="' . esc_url( $translation_permalink ) . '">' . esc_html( $output_translation ) . '</a>' : esc_html( $output_translation ),
+				// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+				$translation_permalink ? '<a href="' . esc_url( $translation_permalink ) . '">' . $output_translation . '</a>' : $output_translation,
 				$user ? esc_html( $user->user_login ) : '&mdash;',
 				$user_last_modified ? esc_html( $user_last_modified->user_login ) : '&mdash;'
 			);


### PR DESCRIPTION
## Problem

The translations with plurals show the "ul" and "li" HTML in the history tab. 

![image](https://user-images.githubusercontent.com/1667814/228482494-67163870-0f81-4c3d-a37f-fc79ed217d14.png)

![image](https://user-images.githubusercontent.com/1667814/228482562-a91c1ecd-748d-4d02-8690-36b77b892ed4.png)

<!--
Please describe what is the status/problem before the PR.
-->

## Solution

This PR removes the escaping to the "ul" and "li" elements, maintaining the escape for the translations.

![image](https://user-images.githubusercontent.com/1667814/228482902-e391e997-7222-4a23-b286-62c0e5c28313.png)

![image](https://user-images.githubusercontent.com/1667814/228483027-b4f24ddf-3416-42f3-a5d6-48f9e2717358.png)

<!--
Please describe how this PR improves the situation.
-->


<!--
## Testing instructions

Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

