### PR TITLE
Preload the translation helpers

### DIFF
--- a/js/editor.js
+++ b/js/editor.js
@@ -261,6 +261,8 @@ jQuery( function( $ ) {
 		}
 
 		if ( translationHelpersCache[ rowId ] === undefined ) {
+			// Store a string with a space to avoid making the same request another time.
+			translationHelpersCache[ rowId ] = ' ';
 			$.getJSON( requestUrl, function( data ) {
 				translationHelpersCache[ rowId ] = data;
 			} );

--- a/js/editor.js
+++ b/js/editor.js
@@ -278,13 +278,19 @@ jQuery( function( $ ) {
 	 * @return {void}
 	 */
 	function updateDataInTabs( data, originalId ) {
-		$( '[data-tab="sidebar-tab-discussion-' + originalId + '"]' ).html( 'Discussion&nbsp;(' + data[ 'helper-translation-discussion-' + originalId ].count + ')' );
-		$( '#sidebar-div-discussion-' + originalId ).html( data[ 'helper-translation-discussion-' + originalId ].content );
-		$( '[data-tab="sidebar-tab-history-' + originalId + '"]' ).html( 'History&nbsp;(' + data[ 'helper-history-' + originalId ].count + ')' );
-		$( '#sidebar-div-history-' + originalId ).html( data[ 'helper-history-' + originalId ].content );
-		$( '[data-tab="sidebar-tab-other-locales-' + originalId + '"]' ).html( 'Other&nbsp;locales&nbsp;(' + data[ 'helper-other-locales-' + originalId ].count + ')' );
-		$( '#sidebar-div-other-locales-' + originalId ).html( data[ 'helper-other-locales-' + originalId ].content );
-		add_copy_button( '#sidebar-div-other-locales-' + originalId );
+		if ( data[ 'helper-translation-discussion-' + originalId ] !== undefined ) {
+			$( '[data-tab="sidebar-tab-discussion-' + originalId + '"]' ).html( 'Discussion&nbsp;(' + data[ 'helper-translation-discussion-' + originalId ].count + ')' );
+			$( '#sidebar-div-discussion-' + originalId ).html( data[ 'helper-translation-discussion-' + originalId ].content );
+		}
+		if ( data[ 'helper-history-' + originalId ] !== undefined ) {
+			$( '[data-tab="sidebar-tab-history-' + originalId + '"]' ).html( 'History&nbsp;(' + data[ 'helper-history-' + originalId ].count + ')' );
+			$( '#sidebar-div-history-' + originalId ).html( data[ 'helper-history-' + originalId ].content );
+		}
+		if ( data[ 'helper-other-locales-' + originalId ] !== undefined ) {
+			$( '[data-tab="sidebar-tab-other-locales-' + originalId + '"]' ).html( 'Other&nbsp;locales&nbsp;(' + data[ 'helper-other-locales-' + originalId ].count + ')' );
+			$( '#sidebar-div-other-locales-' + originalId ).html( data[ 'helper-other-locales-' + originalId ].content );
+			add_copy_button( '#sidebar-div-other-locales-' + originalId );
+		}
 	}
 
 	/**
@@ -306,6 +312,7 @@ jQuery( function( $ ) {
 			translationHelpersCache[ rowId ] = ' ';
 			$.getJSON( requestUrl, function( data ) {
 				translationHelpersCache[ rowId ] = data;
+				updateDataInTabs( data, rowId );
 			} );
 		}
 	}


### PR DESCRIPTION
## Problem

<!--
Please describe what is the status/problem before the PR.
-->

When you want to start translating, and you open the first row, an AJAX query is fired to get the translation helpers. This query needs some time to be transmitted and showed, so you don't see the content immediately. 

## Solution

<!--
Please describe how this PR improves the situation.
-->

This PR adds a local cache for the translation helpers, in 1 local variable:
* For the first row when the page loads, so when the user opens the first row, she gets the translation helpers immediately.
* For the next row, when she opens a row, so when the user opens the next row, she gets the translation helpers immediately.

We only cache what we believe to be the most likely row to be opened next, not all of them, as this avoids making excessive AJAX calls. 

## Testing instructions

I suggest to made, at least, 2 tests with:
* a table with a few strings to translate. You need to review that we only made one request per row (original string).
* a table with only a string to translate. You need to review that we only made one request.

To make your work easier, you can filter in the "Network" tab the "?nohc" text, because all the AJAX queries have this text at the end of the URL.

![image](https://github.com/GlotPress/gp-translation-helpers/assets/1667814/ece8bb3e-1d9a-47f4-852a-af3c2540dacc)

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

