### PR TITLE
Wrap ChatGPT review section in <details> element

### DIFF
--- a/css/discussion.css
+++ b/css/discussion.css
@@ -196,8 +196,8 @@ div#TB_ajaxWindowTitle {
 	font-size: 1.2em;
 	padding: 8px;
 }
-.meta summary.feedback-summary{
-	font-size: 1.2em;
+.meta summary.feedback-summary, .meta summary.chatgpt-summary{
+	font-size: 1.1em;
 	font-weight: bold;
 	padding: 7px 0;
 }

--- a/templates/translation-row-editor-meta-feedback.php
+++ b/templates/translation-row-editor-meta-feedback.php
@@ -4,12 +4,15 @@
 
 if ( 'waiting' === $translation->translation_status || 'fuzzy' === $translation->translation_status ) :
 	?>
-<div>
-	<div class="openai-review">
-		<p class="suggestions__loading-indicator">ChatGPT review in progress <span aria-hidden="true" class="suggestions__loading-indicator__icon"><span></span><span></span><span></span></span></p>
-		<div class="auto-review-result"></div>
+<details open>
+	<summary class="chatgpt-summary"><?php esc_html_e( 'ChatGPT Review', 'glotpress' ); ?></summary>
+	<div>
+		<div class="openai-review">
+			<p class="suggestions__loading-indicator">ChatGPT review in progress <span aria-hidden="true" class="suggestions__loading-indicator__icon"><span></span><span></span><span></span></span></p>
+			<div class="auto-review-result"></div>
+		</div>
 	</div>
-</div>
+</details>
 <?php endif; ?>
 <details open>
 	<summary class="feedback-summary"><?php esc_html_e( 'Give feedback', 'glotpress' ); ?></summary>


### PR DESCRIPTION
#### Problem

ChatGPT review box grows increasingly as the content is being streamed which affects the user experience of translation editors.

#### Solution
Wrap the ChatGPT review section in a `<details>`element, so that users can choose to collapse or reveal the ChatGPT review section

![details-gpt](https://github.com/GlotPress/gp-translation-helpers/assets/2834132/7966f57c-c1f4-42c9-8b6e-ad677d592ea3)


