### PR TITLE
Check if ChatGPT review is enabled by user

### DIFF
--- a/includes/class-gp-translation-helpers.php
+++ b/includes/class-gp-translation-helpers.php
@@ -397,7 +397,6 @@ class GP_Translation_Helpers {
 		gp_enqueue_script( 'gp-comment-feedback-js' );
 
 		$gp_locale             = GP_Locales::by_field( 'slug', $translation_set['locale_slug'] );
-		$gp_translate_settings = get_user_option( 'gp_default_sort' );
 
 		wp_localize_script(
 			'gp-comment-feedback-js',
@@ -409,7 +408,6 @@ class GP_Translation_Helpers {
 				'language'               => $gp_locale ? $gp_locale->english_name : 'Unknown',
 				'openai_key'             => apply_filters( 'gp_get_openai_key', null ),
 				'openai_temperature'     => apply_filters( 'gp_get_openai_temperature', 0.8 ),
-				'chatgpt_review_enabled' => $gp_translate_settings['enable_chatgpt_review'],
 				'comment_reasons'        => Helper_Translation_Discussion::get_comment_reasons( $translation_set['locale_slug'] ),
 			)
 		);

--- a/includes/class-gp-translation-helpers.php
+++ b/includes/class-gp-translation-helpers.php
@@ -396,18 +396,21 @@ class GP_Translation_Helpers {
 		);
 		gp_enqueue_script( 'gp-comment-feedback-js' );
 
-		$gp_locale = GP_Locales::by_field( 'slug', $translation_set['locale_slug'] );
+		$gp_locale             = GP_Locales::by_field( 'slug', $translation_set['locale_slug'] );
+		$gp_translate_settings = get_user_option( 'gp_default_sort' );
+
 		wp_localize_script(
 			'gp-comment-feedback-js',
 			'$gp_comment_feedback_settings',
 			array(
-				'url'                => admin_url( 'admin-ajax.php' ),
-				'nonce'              => wp_create_nonce( 'gp_comment_feedback' ),
-				'locale_slug'        => $translation_set['locale_slug'],
-				'language'           => $gp_locale ? $gp_locale->english_name : 'Unknown',
-				'openai_key'         => apply_filters( 'gp_get_openai_key', null ),
-				'openai_temperature' => apply_filters( 'gp_get_openai_temperature', 0.8 ),
-				'comment_reasons'    => Helper_Translation_Discussion::get_comment_reasons( $translation_set['locale_slug'] ),
+				'url'                    => admin_url( 'admin-ajax.php' ),
+				'nonce'                  => wp_create_nonce( 'gp_comment_feedback' ),
+				'locale_slug'            => $translation_set['locale_slug'],
+				'language'               => $gp_locale ? $gp_locale->english_name : 'Unknown',
+				'openai_key'             => apply_filters( 'gp_get_openai_key', null ),
+				'openai_temperature'     => apply_filters( 'gp_get_openai_temperature', 0.8 ),
+				'chatgpt_review_enabled' => $gp_translate_settings['enable_chatgpt_review'],
+				'comment_reasons'        => Helper_Translation_Discussion::get_comment_reasons( $translation_set['locale_slug'] ),
 			)
 		);
 

--- a/includes/class-gp-translation-helpers.php
+++ b/includes/class-gp-translation-helpers.php
@@ -396,19 +396,18 @@ class GP_Translation_Helpers {
 		);
 		gp_enqueue_script( 'gp-comment-feedback-js' );
 
-		$gp_locale             = GP_Locales::by_field( 'slug', $translation_set['locale_slug'] );
-
+		$gp_locale = GP_Locales::by_field( 'slug', $translation_set['locale_slug'] );
 		wp_localize_script(
 			'gp-comment-feedback-js',
 			'$gp_comment_feedback_settings',
 			array(
-				'url'                    => admin_url( 'admin-ajax.php' ),
-				'nonce'                  => wp_create_nonce( 'gp_comment_feedback' ),
-				'locale_slug'            => $translation_set['locale_slug'],
-				'language'               => $gp_locale ? $gp_locale->english_name : 'Unknown',
-				'openai_key'             => apply_filters( 'gp_get_openai_key', null ),
-				'openai_temperature'     => apply_filters( 'gp_get_openai_temperature', 0.8 ),
-				'comment_reasons'        => Helper_Translation_Discussion::get_comment_reasons( $translation_set['locale_slug'] ),
+				'url'                => admin_url( 'admin-ajax.php' ),
+				'nonce'              => wp_create_nonce( 'gp_comment_feedback' ),
+				'locale_slug'        => $translation_set['locale_slug'],
+				'language'           => $gp_locale ? $gp_locale->english_name : 'Unknown',
+				'openai_key'         => apply_filters( 'gp_get_openai_key', null ),
+				'openai_temperature' => apply_filters( 'gp_get_openai_temperature', 0.8 ),
+				'comment_reasons'    => Helper_Translation_Discussion::get_comment_reasons( $translation_set['locale_slug'] ),
 			)
 		);
 

--- a/js/editor.js
+++ b/js/editor.js
@@ -19,7 +19,8 @@ jQuery( function( $ ) {
 		const tr = $( this ).closest( 'tr.editor' );
 		const rowId = tr.attr( 'row' );
 		const translation_status = tr.find( '.panel-header' ).find( 'span' ).html();
-		const chatgpt_review_enabled = ( 'on' === $gp_comment_feedback_settings.chatgpt_review_enabled );
+		const chatgpt_review_status = JSON.parse( window.localStorage.getItem( 'translate-details-state' ) );
+		const chatgpt_review_enabled = ( 'open' === chatgpt_review_status['details-chatgpt'] );
 
 		if ( focusedRowId === rowId ) {
 			return;

--- a/js/editor.js
+++ b/js/editor.js
@@ -20,7 +20,7 @@ jQuery( function( $ ) {
 		const rowId = tr.attr( 'row' );
 		const translation_status = tr.find( '.panel-header' ).find( 'span' ).html();
 		const chatgpt_review_status = JSON.parse( window.localStorage.getItem( 'translate-details-state' ) );
-		const chatgpt_review_enabled = ( 'open' === chatgpt_review_status['details-chatgpt'] );
+		const chatgpt_review_enabled = ( chatgpt_review_status && 'open' === chatgpt_review_status['details-chatgpt'] ) || ! chatgpt_review_status;
 
 		if ( focusedRowId === rowId ) {
 			return;
@@ -42,6 +42,19 @@ jQuery( function( $ ) {
 		tr.find( '.openai-review .suggestions__loading-indicator' ).show();
 		fetchOpenAIReviewResponse( rowId, tr, true );
 	} );
+
+	$( 'details.details-chatgpt' ).on( 'toggle', function() {
+		const tr = $( this ).closest( 'tr.editor' );
+		const rowId = tr.attr( 'row' );
+		if ($(this).prop( 'open' )) {
+			tr.find( '.openai-review' ).show();
+			tr.find( '.openai-review .auto-review-result' ).html( '' );
+			tr.find( '.openai-review .suggestions__loading-indicator' ).show();
+		  fetchOpenAIReviewResponse( rowId, tr, true );
+		} else {
+			tr.find( '.openai-review' ).hide();
+		}
+} );
 
 	// Shows/hides the reply form for a comment in the discussion.
 	$gp.editor.table.on( 'click', 'a.comment-reply-link', function( event ) {

--- a/js/editor.js
+++ b/js/editor.js
@@ -48,6 +48,9 @@ jQuery( function( $ ) {
 		const rowId = tr.attr( 'row' );
 		if ( $( this ).prop( 'open' ) ) {
 			tr.find( '.openai-review' ).show();
+			if ( tr.find( '.openai-review .auto-review-result' ).children().length ) {
+				return;
+			}
 			tr.find( '.openai-review .auto-review-result' ).html( '' );
 			tr.find( '.openai-review .suggestions__loading-indicator' ).show();
 			fetchOpenAIReviewResponse( rowId, tr, true );

--- a/js/editor.js
+++ b/js/editor.js
@@ -19,13 +19,14 @@ jQuery( function( $ ) {
 		const tr = $( this ).closest( 'tr.editor' );
 		const rowId = tr.attr( 'row' );
 		const translation_status = tr.find( '.panel-header' ).find( 'span' ).html();
+		const chatgpt_review_enabled = ( 'on' === $gp_comment_feedback_settings.chatgpt_review_enabled );
 
 		if ( focusedRowId === rowId ) {
 			return;
 		}
 		focusedRowId = rowId;
 		loadTabsAndDivs( tr );
-		if ( $gp_comment_feedback_settings.openai_key && $gp_editor_options.can_approve && ( 'waiting' === translation_status || 'fuzzy' === translation_status ) ) {
+		if ( chatgpt_review_enabled && $gp_comment_feedback_settings.openai_key && $gp_editor_options.can_approve && ( 'waiting' === translation_status || 'fuzzy' === translation_status ) ) {
 			fetchOpenAIReviewResponse( rowId, tr, false );
 		} else {
 			tr.find( '.openai-review' ).hide();

--- a/js/editor.js
+++ b/js/editor.js
@@ -1,4 +1,4 @@
-/* global $gp, $gp_translation_helpers_editor, wpApiSettings, $gp_comment_feedback_settings, $gp_editor_options, fetch, TextDecoderStream */
+/* global $gp, $gp_translation_helpers_editor, wpApiSettings, $gp_comment_feedback_settings, $gp_editor_options, fetch, TextDecoderStream, window */
 /* eslint camelcase: "off" */
 jQuery( function( $ ) {
 	let focusedRowId = '';
@@ -20,7 +20,7 @@ jQuery( function( $ ) {
 		const rowId = tr.attr( 'row' );
 		const translation_status = tr.find( '.panel-header' ).find( 'span' ).html();
 		const chatgpt_review_status = JSON.parse( window.localStorage.getItem( 'translate-details-state' ) );
-		const chatgpt_review_enabled = ( chatgpt_review_status && 'open' === chatgpt_review_status['details-chatgpt'] ) || ! chatgpt_review_status;
+		const chatgpt_review_enabled = ( chatgpt_review_status && 'open' === chatgpt_review_status[ 'details-chatgpt' ] ) || ! chatgpt_review_status;
 
 		if ( focusedRowId === rowId ) {
 			return;
@@ -46,15 +46,15 @@ jQuery( function( $ ) {
 	$( 'details.details-chatgpt' ).on( 'toggle', function() {
 		const tr = $( this ).closest( 'tr.editor' );
 		const rowId = tr.attr( 'row' );
-		if ($(this).prop( 'open' )) {
+		if ( $( this ).prop( 'open' ) ) {
 			tr.find( '.openai-review' ).show();
 			tr.find( '.openai-review .auto-review-result' ).html( '' );
 			tr.find( '.openai-review .suggestions__loading-indicator' ).show();
-		  fetchOpenAIReviewResponse( rowId, tr, true );
+			fetchOpenAIReviewResponse( rowId, tr, true );
 		} else {
 			tr.find( '.openai-review' ).hide();
 		}
-} );
+	} );
 
 	// Shows/hides the reply form for a comment in the discussion.
 	$gp.editor.table.on( 'click', 'a.comment-reply-link', function( event ) {


### PR DESCRIPTION
#### Problem

Users cannot enable or disable ChatGPT review.

#### Solution

When the user collapses the ChatGPT review (see https://github.com/GlotPress/gp-translation-helpers/pull/174), we should no longer query it.

#### To-do


#### Testing instructions
1. Go to a translation page with waiting or fuzzy strings where you can approve strings.
2. When the ChatGPT review details view is open, ChatGPT should be queried.
3. When you close that details view and go to the next waiting translation, ChatGPT should not be queried.
4. When you now open the review details view, ChatGPT should be queried for that current translation.
5. Close that view again.
6. Reload the page.
7. The ChatGPT review details view should remain closed when opening a waiting string, nothing should be queried.
