### PR TITLE
Add a new tab to merge the "History" and "Other locales" tabs

### DIFF
--- a/css/discussion.css
+++ b/css/discussion.css
@@ -338,3 +338,44 @@ td.gtes-involved a{
     margin-bottom: 0.3em;
     font-size: 1em;
 }
+
+@keyframes loading-indicator {
+	0%, 80%, 100% {
+		opacity: 0;
+	}
+	40% {
+		opacity: 1;
+	}
+}
+
+.suggestions__loading-indicator__icon {
+	font-size: 4px;
+	margin-left: .5rem;
+	line-height: 1;
+	display: inline-block;
+	vertical-align: middle;
+}
+
+.suggestions__loading-indicator__icon span {
+	animation-duration: 1s;
+	animation-delay: 0ms;
+	animation-iteration-count: infinite;
+	animation-name: loading-indicator;
+	animation-timing-function: ease-in-out;
+	background-color: #666;
+	border-radius: 50%;
+	display: inline-block;
+	width: 1em;
+	vertical-align: top;
+	height: 1em;
+}
+
+.suggestions__loading-indicator__icon span:nth-child(2) {
+	animation-delay: 160ms;
+	margin-left: 1em;
+}
+
+.suggestions__loading-indicator__icon span:nth-child(3) {
+	animation-delay: 320ms;
+	margin-left: 1em;
+}

--- a/css/editor.css
+++ b/css/editor.css
@@ -5,34 +5,51 @@
     min-height: 300px;
 }
 
-.meta.discussion, .meta.history, .meta.other-locales {
+.meta.discussion, .meta.others {
     padding: 1rem;
 }
+
 .meta.discussion h6 {
     margin-block: auto;
 }
 
-.meta.history .translations {
+.meta.others .details-history,
+.meta.others .details-other-locales {
+	margin: 1rem 0 -0.5rem 0;
+}
+
+.meta.others .summary-history,
+.meta.others .summary-other-locales {
+	font-weight: bold;
+	margin-bottom: 0.5rem;
+}
+
+.meta.others .sidebar-div-others-history-content {
+	margin-left: 0.5rem;
+}
+
+.meta.others .translations {
     width: 100%;
 }
-.meta.history #translation-history-table thead tr th {
+
+.meta.others #translation-history-table thead tr th {
     font-size: 0.9rem;
     font-weight: 500 !important;
 }
 
-.meta.history #legend > div {
+.meta.others #legend > div {
     margin-top: 0.5rem;
 }
 
-.meta.other-locales ul {
+.meta.others ul {
     list-style: none;
 }
 
-.meta.other-locales span.locale.unique {
-    margin-right: 26px;
+.meta.others span.locale.unique {
+    margin-right: 0.5rem;
 }
 
-.meta.other-locales .other-locales .locale {
+.meta.others .other-locales .locale {
     display: inline-block;
     padding: 1px 6px 0 0;
     margin: 1px 6px 1px 0;
@@ -43,7 +60,11 @@
     color: #fff;
 }
 
-.meta.other-locales .sidebar-other-locales {
+.sidebar-div-others-other-locales-content > ul {
+	padding-left: 1rem;
+}
+
+.meta.others .sidebar-other-locales {
     margin: 0.1rem .5rem;
 }
 

--- a/js/editor.js
+++ b/js/editor.js
@@ -4,10 +4,17 @@ jQuery( function( $ ) {
 	/**
 	 * Stores (caches) the content of the translation helpers, to avoid making the query another time.
 	 *
-	 * @type {Array}
+	 * @type {Object}
 	 */
 	// eslint-disable-next-line prefer-const
-	let translationHelpersCache = [];
+	window.translationHelpersCache = {};
+
+	/**
+	 * Stores the number of items in the "Others" tab.
+	 *
+	 * @type {integer}
+	 */
+	let itemsInOthersTab = 0;
 	let focusedRowId = '';
 	// When a user clicks on a sidebar tab, the visible tab and div changes.
 	$gp.editor.table.on( 'click', '.sidebar-tabs li', function() {
@@ -257,15 +264,17 @@ jQuery( function( $ ) {
 	 * @param {Object} data       The object where we have the data to add.
 	 * @param {number} originalId The id of the original string to translate.
 	 */
-	function add_amount_to_others_tab( sidebarTab, data, originalId ) {
-		let elements = 0;
-		if ( data[ 'helper-history-' + originalId ] !== undefined ) {
-			elements += data[ 'helper-history-' + originalId ].count;
+	if ( typeof window.add_amount_to_others_tab === 'undefined' ) {
+		add_amount_to_others_tab = function(sidebarTab, data, originalId) {
+			let elements = 0;
+			if (data['helper-history-' + originalId] !== undefined) {
+				elements += data['helper-history-' + originalId].count;
+			}
+			if (data['helper-other-locales-' + originalId] !== undefined) {
+				elements += data['helper-other-locales-' + originalId].count;
+			}
+			$('[data-tab="' + sidebarTab + '"]').html('Others&nbsp;(' + elements + ')');
 		}
-		if ( data[ 'helper-other-locales-' + originalId ] !== undefined ) {
-			elements += data[ 'helper-other-locales-' + originalId ].count;
-		}
-		$( '[data-tab="' + sidebarTab + '"]' ).html( 'Others&nbsp;(' + elements + ')' );
 	}
 
 	/**
@@ -302,7 +311,7 @@ jQuery( function( $ ) {
 		if ( data[ 'helper-history-' + originalId ] !== undefined ) {
 			$( '#summary-history-' + originalId ).html( 'History&nbsp;(' + data[ 'helper-history-' + originalId ].count + ')' );
 			$( '#sidebar-div-others-history-content-' + originalId ).html( data[ 'helper-history-' + originalId ].content );
-			add_amount_to_others_tab( '#sidebar-tab-others-' + originalId, data, originalId );
+			add_amount_to_others_tab( 'sidebar-tab-others-' + originalId, data, originalId );
 		} else {
 			$( '#sidebar-div-others-history-content-' + originalId ).html( '' );
 		}

--- a/js/editor.js
+++ b/js/editor.js
@@ -233,8 +233,6 @@ jQuery( function( $ ) {
 		$( '#sidebar-div-meta-' + originalId ).hide();
 		$( '#sidebar-div-discussion-' + originalId ).hide();
 		$( '#sidebar-div-others-' + originalId ).hide();
-		$( '#sidebar-div-history-' + originalId ).hide();
-		$( '#sidebar-div-other-locales-' + originalId ).hide();
 		$( '#' + tabId ).show();
 	}
 
@@ -252,6 +250,13 @@ jQuery( function( $ ) {
 		} );
 	}
 
+	/**
+	 * Adds the amount of elements to the "Others" tab.
+	 *
+	 * @param {string} sidebarTab The tab where we add the amount of elements.
+	 * @param {Object} data       The object where we have the data to add.
+	 * @param {number} originalId The id of the original string to translate.
+	 */
 	function add_amount_to_others_tab( sidebarTab, data, originalId ) {
 		let elements = 0;
 		if ( data[ 'helper-history-' + originalId ] !== undefined ) {
@@ -295,12 +300,14 @@ jQuery( function( $ ) {
 			$( '#sidebar-div-discussion-' + originalId ).html( data[ 'helper-translation-discussion-' + originalId ].content );
 		}
 		if ( data[ 'helper-history-' + originalId ] !== undefined ) {
+			$( '#summary-history-' + originalId ).html( 'History&nbsp;(' + data[ 'helper-history-' + originalId ].count + ')' );
 			$( '#sidebar-div-others-history-content-' + originalId ).html( data[ 'helper-history-' + originalId ].content );
 			add_amount_to_others_tab( '#sidebar-tab-others-' + originalId, data, originalId );
 		} else {
 			$( '#sidebar-div-others-history-content-' + originalId ).html( '' );
 		}
 		if ( data[ 'helper-other-locales-' + originalId ] !== undefined ) {
+			$( '#summary-other-locales-' + originalId ).html( 'Other&nbsp;locales&nbsp;(' + data[ 'helper-other-locales-' + originalId ].count + ')' );
 			$( '#sidebar-div-others-other-locales-content-' + originalId ).html( data[ 'helper-other-locales-' + originalId ].content );
 			add_copy_button( '#sidebar-div-others-other-locales-content-' + originalId );
 			add_amount_to_others_tab( 'sidebar-tab-others-' + originalId, data, originalId );

--- a/js/editor.js
+++ b/js/editor.js
@@ -1,4 +1,4 @@
-/* global document, $gp, $gp_translation_helpers_editor, wpApiSettings, $gp_comment_feedback_settings, $gp_editor_options, fetch, TextDecoderStream, URL, URLSearchParams, window */
+/* global document, $gp, $gp_translation_helpers_editor, wpApiSettings, $gp_comment_feedback_settings, $gp_editor_options, fetch, TextDecoderStream, URL, URLSearchParams, window, translationHelpersCache, add_amount_to_others_tab */
 /* eslint camelcase: "off" */
 jQuery( function( $ ) {
 	/**
@@ -9,12 +9,6 @@ jQuery( function( $ ) {
 	// eslint-disable-next-line prefer-const
 	window.translationHelpersCache = {};
 
-	/**
-	 * Stores the number of items in the "Others" tab.
-	 *
-	 * @type {integer}
-	 */
-	let itemsInOthersTab = 0;
 	let focusedRowId = '';
 	// When a user clicks on a sidebar tab, the visible tab and div changes.
 	$gp.editor.table.on( 'click', '.sidebar-tabs li', function() {
@@ -265,16 +259,16 @@ jQuery( function( $ ) {
 	 * @param {number} originalId The id of the original string to translate.
 	 */
 	if ( typeof window.add_amount_to_others_tab === 'undefined' ) {
-		add_amount_to_others_tab = function(sidebarTab, data, originalId) {
+		add_amount_to_others_tab = function( sidebarTab, data, originalId ) {
 			let elements = 0;
-			if (data['helper-history-' + originalId] !== undefined) {
-				elements += data['helper-history-' + originalId].count;
+			if ( data[ 'helper-history-' + originalId ] !== undefined ) {
+				elements += data[ 'helper-history-' + originalId ].count;
 			}
-			if (data['helper-other-locales-' + originalId] !== undefined) {
-				elements += data['helper-other-locales-' + originalId].count;
+			if ( data[ 'helper-other-locales-' + originalId ] !== undefined ) {
+				elements += data[ 'helper-other-locales-' + originalId ].count;
 			}
-			$('[data-tab="' + sidebarTab + '"]').html('Others&nbsp;(' + elements + ')');
-		}
+			$( '[data-tab="' + sidebarTab + '"]' ).html( 'Others&nbsp;(' + elements + ')' );
+		};
 	}
 
 	/**

--- a/js/editor.js
+++ b/js/editor.js
@@ -232,6 +232,7 @@ jQuery( function( $ ) {
 	function change_visible_div( tabId, originalId ) {
 		$( '#sidebar-div-meta-' + originalId ).hide();
 		$( '#sidebar-div-discussion-' + originalId ).hide();
+		$( '#sidebar-div-others-' + originalId ).hide();
 		$( '#sidebar-div-history-' + originalId ).hide();
 		$( '#sidebar-div-other-locales-' + originalId ).hide();
 		$( '#' + tabId ).show();
@@ -249,6 +250,17 @@ jQuery( function( $ ) {
 			html += '<button class="sidebar-other-locales button is-small copy-suggestion"> Copy </button>';
 			$( this ).html( html );
 		} );
+	}
+
+	function add_amount_to_others_tab( sidebarTab, data, originalId ) {
+		let elements = 0;
+		if ( data[ 'helper-history-' + originalId ] !== undefined ) {
+			elements += data[ 'helper-history-' + originalId ].count;
+		}
+		if ( data[ 'helper-other-locales-' + originalId ] !== undefined ) {
+			elements += data[ 'helper-other-locales-' + originalId ].count;
+		}
+		$( '[data-tab="' + sidebarTab + '"]' ).html( 'Others&nbsp;(' + elements + ')' );
 	}
 
 	/**
@@ -283,13 +295,17 @@ jQuery( function( $ ) {
 			$( '#sidebar-div-discussion-' + originalId ).html( data[ 'helper-translation-discussion-' + originalId ].content );
 		}
 		if ( data[ 'helper-history-' + originalId ] !== undefined ) {
-			$( '[data-tab="sidebar-tab-history-' + originalId + '"]' ).html( 'History&nbsp;(' + data[ 'helper-history-' + originalId ].count + ')' );
-			$( '#sidebar-div-history-' + originalId ).html( data[ 'helper-history-' + originalId ].content );
+			$( '#sidebar-div-others-history-content-' + originalId ).html( data[ 'helper-history-' + originalId ].content );
+			add_amount_to_others_tab( '#sidebar-tab-others-' + originalId, data, originalId );
+		} else {
+			$( '#sidebar-div-others-history-content-' + originalId ).html( '' );
 		}
 		if ( data[ 'helper-other-locales-' + originalId ] !== undefined ) {
-			$( '[data-tab="sidebar-tab-other-locales-' + originalId + '"]' ).html( 'Other&nbsp;locales&nbsp;(' + data[ 'helper-other-locales-' + originalId ].count + ')' );
-			$( '#sidebar-div-other-locales-' + originalId ).html( data[ 'helper-other-locales-' + originalId ].content );
-			add_copy_button( '#sidebar-div-other-locales-' + originalId );
+			$( '#sidebar-div-others-other-locales-content-' + originalId ).html( data[ 'helper-other-locales-' + originalId ].content );
+			add_copy_button( '#sidebar-div-others-other-locales-content-' + originalId );
+			add_amount_to_others_tab( 'sidebar-tab-others-' + originalId, data, originalId );
+		} else {
+			$( '#sidebar-div-others-other-locales-content-' + originalId ).html( '' );
 		}
 	}
 

--- a/templates/gp-templates-overrides/translation-row-editor-meta.php
+++ b/templates/gp-templates-overrides/translation-row-editor-meta.php
@@ -171,13 +171,20 @@ $sidebar_tabs  = '<nav class="nav-sidebar">';
 $sidebar_tabs .= '<ul class="sidebar-tabs">';
 $sidebar_tabs .= '	<li class="current tab-meta" data-tab="sidebar-tab-meta-' . $translation->row_id . '" data-row-id="' . $translation->row_id . '">Meta</li>';
 $sidebar_tabs .= '	<li class="tab-discussion" data-tab="sidebar-tab-discussion-' . $translation->row_id . '" data-row-id="' . $translation->row_id . '">Discussion&nbsp;<span class="count"></span></li>';
-$sidebar_tabs .= '	<li class="tab-history" data-tab="sidebar-tab-history-' . $translation->row_id . '" data-row-id="' . $translation->row_id . '">History&nbsp;<span class="count"></span></li>';
-$sidebar_tabs .= '	<li class="tab-other-locales" data-tab="sidebar-tab-other-locales-' . $translation->row_id . '" data-row-id="' . $translation->row_id . '">Other&nbsp;locales&nbsp;<span class="count"></span></li>';
+$sidebar_tabs .= '	<li class="tab-others" data-tab="sidebar-tab-others-' . $translation->row_id . '" data-row-id="' . $translation->row_id . '">Others&nbsp;<span class="count"></span></li>';
 $sidebar_tabs .= '</ul>';
 $sidebar_tabs .= $meta_sidebar;
 $sidebar_tabs .= '<div class="meta discussion" id="sidebar-div-discussion-' . $translation->row_id . '"  data-row-id="' . $translation->row_id . '" style="display: none;"></div>';
-$sidebar_tabs .= '<div class="meta history" id="sidebar-div-history-' . $translation->row_id . '"  data-row-id="' . $translation->row_id . '" style="display: none;"></div>';
-$sidebar_tabs .= '<div class="meta other-locales" id="sidebar-div-other-locales-' . $translation->row_id . '"  data-row-id="' . $translation->row_id . '" style="display: none;"></div>';
+$sidebar_tabs .= '<div class="meta others" id="sidebar-div-others-' . $translation->row_id . '"  data-row-id="' . $translation->row_id . '" style="display: none;">';
+$sidebar_tabs .= '    <details class="details-other-locales" open="">';
+$sidebar_tabs .= '        <summary class="summary-other-locales" id="summary-other-locales-' . $translation->row_id . '">Other locales</summary>';
+$sidebar_tabs .= '        <div class="sidebar-div-others-other-locales-content" id="sidebar-div-others-other-locales-content-' . $translation->row_id . '"></div>';
+$sidebar_tabs .= '    </details>';
+$sidebar_tabs .= '    <details class="details-history" open="">';
+$sidebar_tabs .= '        <summary class="summary-history" id="summary-history-' . $translation->row_id . '">History</summary>';
+$sidebar_tabs .= '        <div class="sidebar-div-others-history-content" id="sidebar-div-others-history-content-' . $translation->row_id . '"></div>';
+$sidebar_tabs .= '    </details>';
+$sidebar_tabs .= '</div>'; /* meta others */
 $sidebar_tabs .= '</nav>';
 
 // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped

--- a/templates/gp-templates-overrides/translation-row-editor-meta.php
+++ b/templates/gp-templates-overrides/translation-row-editor-meta.php
@@ -176,14 +176,18 @@ $sidebar_tabs .= '</ul>';
 $sidebar_tabs .= $meta_sidebar;
 $sidebar_tabs .= '<div class="meta discussion" id="sidebar-div-discussion-' . $translation->row_id . '"  data-row-id="' . $translation->row_id . '" style="display: none;"></div>';
 $sidebar_tabs .= '<div class="meta others" id="sidebar-div-others-' . $translation->row_id . '"  data-row-id="' . $translation->row_id . '" style="display: none;">';
-$sidebar_tabs .= '    <details class="details-other-locales" open="">';
-$sidebar_tabs .= '        <summary class="summary-other-locales" id="summary-other-locales-' . $translation->row_id . '">Other locales</summary>';
-$sidebar_tabs .= '        <div class="sidebar-div-others-other-locales-content" id="sidebar-div-others-other-locales-content-' . $translation->row_id . '"></div>';
-$sidebar_tabs .= '    </details>';
-$sidebar_tabs .= '    <details class="details-history" open="">';
-$sidebar_tabs .= '        <summary class="summary-history" id="summary-history-' . $translation->row_id . '">History</summary>';
-$sidebar_tabs .= '        <div class="sidebar-div-others-history-content" id="sidebar-div-others-history-content-' . $translation->row_id . '"></div>';
-$sidebar_tabs .= '    </details>';
+$sidebar_tabs .= '	<details class="details-other-locales" open="">';
+$sidebar_tabs .= '		<summary class="summary-other-locales" id="summary-other-locales-' . $translation->row_id . '">Other locales';
+$sidebar_tabs .= '			<span aria-hidden="true" class="suggestions__loading-indicator__icon"><span></span><span></span><span></span></span>';
+$sidebar_tabs .= '		</summary>';
+$sidebar_tabs .= '		<div class="sidebar-div-others-other-locales-content" id="sidebar-div-others-other-locales-content-' . $translation->row_id . '"></div>';
+$sidebar_tabs .= '	</details>';
+$sidebar_tabs .= '	<details class="details-history" open="">';
+$sidebar_tabs .= '		<summary class="summary-history" id="summary-history-' . $translation->row_id . '">History';
+$sidebar_tabs .= '			<span aria-hidden="true" class="suggestions__loading-indicator__icon"><span></span><span></span><span></span></span>';
+$sidebar_tabs .= '		</summary>';
+$sidebar_tabs .= '		<div class="sidebar-div-others-history-content" id="sidebar-div-others-history-content-' . $translation->row_id . '"></div>';
+$sidebar_tabs .= '	</details>';
 $sidebar_tabs .= '</div>'; /* meta others */
 $sidebar_tabs .= '</nav>';
 


### PR DESCRIPTION
## Problem

<!--
Please describe what is the status/problem before the PR.
-->

Currently, we have 4 tabs in the right sidebar to show different information:
- Meta.
- Discuss.
- History.
- Other locales.

![image](https://github.com/GlotPress/gp-translation-helpers/assets/1667814/8e029d78-b7a6-4ead-a6e3-ed21f619827f)

At [translate.wordpress.org](https://translate.wordpress.org/) we have added a fifth tab with the translation memory:

![image](https://github.com/GlotPress/gp-translation-helpers/assets/1667814/df7640e2-c3d4-4693-af4a-8439694847d4)

These tabs take up a lot of horizontal space with small devices and/or screens, showing tabs with only a few letters and without the number of elements, with a bad usability.

![image](https://github.com/GlotPress/gp-translation-helpers/assets/1667814/b2912bb1-e4e0-4961-a8ec-5b442e2097ef)

## Solution

<!--
Please describe how this PR improves the situation.
-->

This PR merges the content from the "History" and "Other locales" in a new tab, called "Others", removing the two previous tabs.

![image](https://github.com/GlotPress/gp-translation-helpers/assets/1667814/df3e7cb0-3a25-4a55-ab6b-099ae4234985)

This PR adds "summary" elements, so the user could show or hide the different elements. This PR doesn't remember the status of each summary (opened or closed).

![image](https://github.com/GlotPress/gp-translation-helpers/assets/1667814/713e53bb-575a-4039-bee9-dcd6dbdd74e7)

## Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

To test this PR you have to access to a project with some locales and translations in the other locales and check:

1) If the other locales don't have any translation and the current one doesn't have, too, you are going to get an empty tab:

![image](https://github.com/GlotPress/gp-translation-helpers/assets/1667814/31458576-63a1-4e07-beae-3e7bdba33505)

2) If the other locales have a translation, but the current one doesn't have it, you are going to get a tab with only the feedback from the other locales:

![image](https://github.com/GlotPress/gp-translation-helpers/assets/1667814/10a8cc55-4549-4301-9e13-476241c4afbc)

3) If the other locales don't have a translation, but the current one has it, you are going to get a tab with only the history from the current locale:

![image](https://github.com/GlotPress/gp-translation-helpers/assets/1667814/5aa974b3-c5d9-4785-9ac4-45e32baf70eb)

4) If the other locales and the current one have translations, you are going to get a tab with feedback from another locales and history from the current one:

![image](https://github.com/GlotPress/gp-translation-helpers/assets/1667814/16dea413-d715-4be7-8fb8-49d989d81c0a)
