### PR TITLE
Check if the mentions function exists

### DIFF
--- a/helpers-assets/templates/translation-discussion-comments.php
+++ b/helpers-assets/templates/translation-discussion-comments.php
@@ -172,11 +172,11 @@
 		);
 		echo '</div>';
 		?>
-		
+
 		<?php if ( $comments ) : ?>
 			</details>
 		<?php endif; ?>
-		
+
 			<?php
 	} else {
 		/* translators: Log in URL. */
@@ -184,11 +184,11 @@
 	}
 	?>
 </div><!-- .discussion-wrapper -->
-<script>	
+<script>
 	jQuery(function( e, mentions ) {
 		var mentionsList = '<?php echo wp_json_encode( $mentions_list ); ?>';
 		var jetpackMentionsData = JSON.parse( mentionsList );
-		if( jetpackMentionsData.length > 0 ) {
+		if( jetpackMentionsData.length > 0 && typeof jQuery.fn.mentions !== 'undefined' ) {
 			jQuery( 'textarea#comment' ).mentions( jetpackMentionsData );
 		}
 	});


### PR DESCRIPTION
## Problem

<!--
Please describe what is the status/problem before the PR.
-->

When the system doesn't have a user logged, it shows the next error in the JavaScript console when we are in a page with a list of strings. It is independent of the translation state of these strings.

![image](https://github.com/GlotPress/gp-translation-helpers/assets/1667814/d3364a9f-a84d-4f55-85ee-dbaad9e4be64)


Reported by @psmits1567 [here](https://github.com/GlotPress/gp-translation-helpers/pull/113#issuecomment-1637481800). 

## Solution

The problem is happening at DotOrg because the system doesn't load the `mentions` file if the user is not logged.

Without a logged user:

![image](https://github.com/GlotPress/gp-translation-helpers/assets/1667814/bf5a91c7-1634-470b-ac26-372fae70a7c8)

With a logged user:

![image](https://github.com/GlotPress/gp-translation-helpers/assets/1667814/7a8c57f3-d8f4-402c-a1b0-7027ef5dc97c)

<!--
Please describe how this PR improves the situation.
-->

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Load a list of strings in a project and take a look at the JavaScript console, to see that now you don't see the error message.
