### PR TITLE
Reorder the preference for other locales

### DIFF
--- a/helpers/helper-other-locales.php
+++ b/helpers/helper-other-locales.php
@@ -32,6 +32,21 @@ class Helper_Other_Locales extends GP_Translation_Helper {
 	public $has_async_content = true;
 
 	/**
+	 * Indicates the related locales for each locale, so we will put them in the top list
+	 * of "Other locales".
+	 *
+	 * This array should be sync with
+	 * https://github.com/WordPress/wordpress.org/blob/trunk/wordpress.org/public_html/wp-content/plugins/wporg-gp-translation-suggestions/inc/routes/class-other-languages.php
+	 *
+	 * @since 0.0.1
+	 * @var array
+	 */
+	public array $related_locales = array(
+		'gl' => array( 'es', 'pt', 'pt-ao', 'pt-br', 'ca', 'it', 'fr', 'ro' ),
+		'es' => array( 'gl', 'ca', 'pt', 'pt-ao', 'pt-br', 'it', 'fr', 'ro' ),
+	);
+
+	/**
 	 * Activates the helper.
 	 *
 	 * @since 0.0.2
@@ -66,13 +81,14 @@ class Helper_Other_Locales extends GP_Translation_Helper {
 			$translation_set = GP::$translation_set->by_project_id_slug_and_locale( $this->data['project_id'], $this->data['translation_set_slug'], $this->data['locale_slug'] );
 		}
 
-		$translations           = GP::$translation->find_many_no_map(
+		$translations                           = GP::$translation->find_many_no_map(
 			array(
 				'status'      => 'current',
 				'original_id' => $this->data['original_id'],
 			)
 		);
-		$translations_by_locale = array();
+		$translations_by_locale                 = array();
+		$translations_by_locale_with_preference = array();
 		foreach ( $translations as $translation ) {
 			$_set = GP::$translation_set->get( $translation->translation_set_id );
 			if ( ! $_set || ( $translation_set && intval( $translation->translation_set_id ) === intval( $translation_set->id ) ) ) {
@@ -83,7 +99,26 @@ class Helper_Other_Locales extends GP_Translation_Helper {
 
 		ksort( $translations_by_locale );
 
-		return $translations_by_locale;
+		// Put the variants in the top list.
+		foreach ( $translations_by_locale as $key => $translation ) {
+			// phpcs:ignore WordPress.PHP.YodaConditions.NotYoda
+			if ( explode( '-', $key )[0] === explode( '-', $this->data['locale_slug'] )[0] ) {
+				$translations_by_locale_with_preference[ $key ] = $translation;
+				unset( $translations_by_locale[ $key ] );
+			}
+		}
+
+		// Put the related locales in the top list, after the variants.
+		if ( ! empty( $this->related_locales[ $this->data['locale_slug'] ] ) ) {
+			foreach ( $this->related_locales[ $this->data['locale_slug'] ] as $locale ) {
+				if ( array_key_exists( $locale, $translations_by_locale ) ) {
+					$translations_by_locale_with_preference[ $locale ] = $translations_by_locale[ $locale ];
+					unset( $translations_by_locale[ $locale ] );
+				}
+			}
+		}
+
+		return array_merge( $translations_by_locale_with_preference, $translations_by_locale );
 	}
 
 	/**


### PR DESCRIPTION
## Problem

In the "[Improving Translation Suggestions [Other Languages]](https://make.wordpress.org/polyglots/2023/05/31/improving-translation-suggestions-other-languages/)" P2 we proposed to add an improvement to put in the top place the translations from languages related with the current translation. 
<!--
Please describe what is the status/problem before the PR.
-->

## Solution

This PR adds:
- an array with the related languages for each locale. This should be improved, with new locales, in the future. In this PR I have only added related languages for Galician and Spanish. You need to use the `slug` property from each `GP_Locale` from [GlotPress](https://github.com/GlotPress/GlotPress/blob/develop/locales/locales.php) or from the [DotOrg environment](https://github.com/WordPress/wordpress.org/blob/trunk/wordpress.org/public_html/wp-content/mu-plugins/pub/locales/locales.php).
- a reorder method, to put on the top list the variants for this locale (e.g., if you are translating to Spanish (Colombia), you are going to have in the top list the other Spanish variants.
- another reorder method, to use the previous array to put this related locales just after the language variants.

**Some examples from [translate.w.org](https://translate.wordpress.org/)**

Translation to Spanish (Spain) with Spanish variants and related locales. [Link](https://translate.wordpress.org/projects/wp/dev/es/default/?filters%5Boriginal_id%5D=6929622&filters%5Bstatus%5D=either&filters%5Btranslation_id%5D=59173494).

![image](https://github.com/GlotPress/gp-translation-helpers/assets/1667814/2b404ca9-7630-476b-ab8a-be7855250ba8)

Translation to Spanish (Colombia) with Spanish variants but without related locales. [Link](https://translate.wordpress.org/projects/wp/dev/es-co/default/?filters%5Bstatus%5D=either&filters%5Boriginal_id%5D=6929622&filters%5Btranslation_id%5D=59601111).

![image](https://github.com/GlotPress/gp-translation-helpers/assets/1667814/1314178e-e7b9-469c-ae88-ad723039a651)

Translation to Spanish (Spain) with relate locales but without Spanish variants, because these variants doesn't have any translations for this original string. [Link](https://translate.wordpress.org/projects/apps/ios/dev/es/default/?filters%5Bstatus%5D=either&filters%5Boriginal_id%5D=16114703&filters%5Btranslation_id%5D=106976241).

![image](https://github.com/GlotPress/gp-translation-helpers/assets/1667814/64488fd3-4885-44ff-9c89-14c6b7671760)

Translation to Italian without variants or related languages. [Link](https://translate.wordpress.org/projects/apps/ios/dev/it/default/?filters%5Boriginal_id%5D=16114703&filters%5Bstatus%5D=either&filters%5Btranslation_id%5D=106977633). 

![image](https://github.com/GlotPress/gp-translation-helpers/assets/1667814/7e66f1dd-4603-4286-a969-9c7fb72e14e0)

Translation to Dutch with variants (Dutch formal and Dutch (Belgium)). [Link](https://translate.wordpress.org/projects/wp/dev/nl/default/?filters%5Boriginal_id%5D=6929622&filters%5Bstatus%5D=either&filters%5Btranslation_id%5D=59173446). 

![image](https://github.com/GlotPress/gp-translation-helpers/assets/1667814/3bc7ef2c-6296-420f-94a5-6ba418283901)

<!--
Please describe how this PR improves the situation.
-->

<!--
## Testing instructions

Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

