### PR TITLE
Add the related locales to Occitan

### DIFF
--- a/helpers/helper-other-locales.php
+++ b/helpers/helper-other-locales.php
@@ -42,8 +42,9 @@ class Helper_Other_Locales extends GP_Translation_Helper {
 	 * @var array
 	 */
 	public array $related_locales = array(
-		'gl' => array( 'es', 'pt', 'pt-ao', 'pt-br', 'ca', 'it', 'fr', 'ro' ),
-		'es' => array( 'gl', 'ca', 'pt', 'pt-ao', 'pt-br', 'it', 'fr', 'ro' ),
+		'gl'  => array( 'es', 'pt', 'pt-ao', 'pt-br', 'ca', 'it', 'fr', 'ro' ),
+		'es'  => array( 'gl', 'ca', 'pt', 'pt-ao', 'pt-br', 'it', 'fr', 'ro' ),
+		'oci' => array( 'ca', 'fr', 'it', 'es', 'gl' ),
 	);
 
 	/**


### PR DESCRIPTION
## Problem

The plugin doesn't have the related locales to Occitan.

Solves https://github.com/GlotPress/gp-translation-helpers/issues/188.

<!--
Please describe what is the status/problem before the PR.
-->

## Solution

This PR adds an array with the related locales to Occitan.
<!--
Please describe how this PR improves the situation.
-->


