### PR TITLE
Change the returned Content-Type from text/html to application/json

### DIFF
--- a/includes/class-gp-route-translation-helpers.php
+++ b/includes/class-gp-route-translation-helpers.php
@@ -309,7 +309,7 @@ class GP_Route_Translation_Helpers extends GP_Route {
 			};
 		}
 
-		echo wp_json_encode( $sections );
+		wp_send_json( $sections );
 	}
 
 	/**


### PR DESCRIPTION
## Problem

This plugin has [2 endpoints](https://github.com/GlotPress/gp-translation-helpers/blob/c012fdf90b0f3dd984553fdb4b851bf9a67dabe6/includes/class-gp-translation-helpers.php#L336-L337) who response with AJAX content, but their `Content-Type` is `text/html`, so when you access with a web browser, the content is bad-formatted.

![image](https://github.com/GlotPress/gp-translation-helpers/assets/1667814/ebfc8d6c-d78a-4df3-8563-7bb1a2a45fbc)

Fixes https://github.com/GlotPress/gp-translation-helpers/issues/182.

Props @Presskopp
<!--
Please describe what is the status/problem before the PR.
-->

## Solution

This PR changes the `Content-Type` from `text/html` to `application/json`, so the content type is the correct and is well-formatted as JSON in the web browser.

![image](https://github.com/GlotPress/gp-translation-helpers/assets/1667814/0975d933-8c02-4335-851b-322f4fe49ee3)

If you use some JSON viewer browser plugin (e.g. [JSONVue](https://github.com/gildas-lormeau/JSONVue)), you can see it is well-formatted.

![image](https://github.com/GlotPress/gp-translation-helpers/assets/1667814/4fe10373-07e0-4ad0-a953-6a0a0314a9fc)

<!--
Please describe how this PR improves the situation.
-->

