### PR TITLE
Fixes deprecation notice in PHP8 for usort returning bool

### DIFF
--- a/includes/class-gp-route-translation-helpers.php
+++ b/includes/class-gp-route-translation-helpers.php
@@ -230,7 +230,7 @@ class GP_Route_Translation_Helpers extends GP_Route {
 		usort(
 			$sections,
 			function( $s1, $s2 ) {
-				return $s1['priority'] > $s2['priority'];
+				return $s1['priority'] <=> $s2['priority'];
 			}
 		);
 


### PR DESCRIPTION
## Problem

With PHP 8.0, I get this error:

`Deprecated: usort(): Returning bool from comparison function is deprecated, return an integer less than, equal to, or greater than zero in /wordpress/glotpress/wp-content/plugins/gp-translation-helpers/includes/class-gp-route-translation-helpers.php on line 234`

This is the same problem that this one https://github.com/GlotPress/GlotPress/pull/1464.

Fixes https://github.com/GlotPress/gp-translation-helpers/issues/194.

<!--
Please describe what is the status/problem before the PR.
-->

## Solution

Change the `>` operator to the `<=>` operator into the usort user-defined comparison function.

<!--
Please describe how this PR improves the situation.
-->

