### PR TITLE
Add the related locales to Italian

### DIFF
--- a/helpers/helper-other-locales.php
+++ b/helpers/helper-other-locales.php
@@ -45,6 +45,7 @@ class Helper_Other_Locales extends GP_Translation_Helper {
 		'ca'  => array( 'ca-val', 'bal', 'es', 'oci', 'an', 'gl', 'fr', 'it', 'pt', 'ro', 'la' ),
 		'es'  => array( 'gl', 'ca', 'pt', 'pt-ao', 'pt-br', 'it', 'fr', 'ro' ),
 		'gl'  => array( 'es', 'pt', 'pt-ao', 'pt-br', 'ca', 'it', 'fr', 'ro' ),
+		'it'  => array( 'ca', 'de', 'es', 'fr', 'pt', 'ro' ),
 		'oci' => array( 'ca', 'fr', 'it', 'es', 'gl' ),
 	);
 


### PR DESCRIPTION
## Problem

The plugin doesn't have the related locales to Italian.

[Fixes https://github.com/GlotPress/gp-translation-helpers/issues/191](https://github.com/GlotPress/gp-translation-helpers/issues/196).

<!--
Please describe what is the status/problem before the PR.
-->

## Solution

This PR adds an array with the related locales to Italian.
<!--
Please describe how this PR improves the situation.
-->


