### PR TITLE
Add the related locales to Uighur

### DIFF
--- a/helpers/helper-other-locales.php
+++ b/helpers/helper-other-locales.php
@@ -47,6 +47,7 @@ class Helper_Other_Locales extends GP_Translation_Helper {
 		'gl'  => array( 'es', 'pt', 'pt-ao', 'pt-br', 'ca', 'it', 'fr', 'ro' ),
 		'it'  => array( 'ca', 'de', 'es', 'fr', 'pt', 'ro' ),
 		'oci' => array( 'ca', 'fr', 'it', 'es', 'gl' ),
+		'ug'  => array( 'tr', 'uz', 'az', 'zh-cn', 'zh-tw' ),
 	);
 
 	/**


### PR DESCRIPTION
## Problem

The plugin doesn't have the related locales to Uighur.

Fixes https://github.com/GlotPress/gp-translation-helpers/issues/201.

Proposed by [Nureli Tashpolat](https://profiles.wordpress.org/sepra/) (@Nureli-Tashpolat), who is a [Uighur LM and GTE](https://make.wordpress.org/polyglots/teams/?locale=ug_CN).

<!--
Please describe what is the status/problem before the PR.
-->

## Solution

This PR adds an array with the related locales to Uighur.
<!--
Please describe how this PR improves the situation.
-->


