### PR TITLE
Add the related locales to Nepali

### DIFF
--- a/helpers/helper-other-locales.php
+++ b/helpers/helper-other-locales.php
@@ -46,6 +46,7 @@ class Helper_Other_Locales extends GP_Translation_Helper {
 		'es'  => array( 'gl', 'ca', 'pt', 'pt-ao', 'pt-br', 'it', 'fr', 'ro' ),
 		'gl'  => array( 'es', 'pt', 'pt-ao', 'pt-br', 'ca', 'it', 'fr', 'ro' ),
 		'it'  => array( 'ca', 'de', 'es', 'fr', 'pt', 'ro' ),
+		'ne'  => array( 'hi', 'mr', 'as' ),
 		'oci' => array( 'ca', 'fr', 'it', 'es', 'gl' ),
 		'ug'  => array( 'tr', 'uz', 'az', 'zh-cn', 'zh-tw' ),
 	);


### PR DESCRIPTION
## Problem

The plugin doesn't have the related locales to Nepali.

Fixes https://github.com/GlotPress/gp-translation-helpers/issues/206.

Proposed by [Nilambar Sharma](https://profiles.wordpress.org/rabmalin/) (@ernilambar), who is a [Nepali LM and GTE](https://make.wordpress.org/polyglots/teams/?locale=ne_NP).

<!--
Please describe what is the status/problem before the PR.
-->

## Solution

This PR adds an array with the related locales to Nepali.
<!--
Please describe how this PR improves the situation.
-->


