### PR TITLE
Add a new AI checkbox to the "Give feedback" section

### DIFF
--- a/helpers/helper-translation-discussion.php
+++ b/helpers/helper-translation-discussion.php
@@ -830,7 +830,7 @@ class Helper_Translation_Discussion extends GP_Translation_Helper {
 				'name'        => __( 'Typo' ),
 				'explanation' => __( 'The translation has a typo. E.g., it is using the \'apostrope\' word instead of \'apostrophe\'.' ),
 			),
-			'ia'          => array(
+			'ai'          => array(
 				'name'        => __( 'AI' ),
 				'explanation' => __( 'The translator has used some AI or other machine translation tool without additional manual review, and its quality is low.' ),
 			),

--- a/helpers/helper-translation-discussion.php
+++ b/helpers/helper-translation-discussion.php
@@ -830,6 +830,10 @@ class Helper_Translation_Discussion extends GP_Translation_Helper {
 				'name'        => __( 'Typo' ),
 				'explanation' => __( 'The translation has a typo. E.g., it is using the \'apostrope\' word instead of \'apostrophe\'.' ),
 			),
+			'ia'          => array(
+				'name'        => __( 'AI' ),
+				'explanation' => __( 'The translator has used some AI or other machine translation tool without additional manual review, and its quality is low.' ),
+			),
 		);
 		$reasons         = apply_filters( 'gp_custom_reasons', $default_reasons, $locale );
 		return $reasons;

--- a/helpers/helper-translation-discussion.php
+++ b/helpers/helper-translation-discussion.php
@@ -831,7 +831,7 @@ class Helper_Translation_Discussion extends GP_Translation_Helper {
 				'explanation' => __( 'The translation has a typo. E.g., it is using the \'apostrope\' word instead of \'apostrophe\'.' ),
 			),
 			'ai'          => array(
-				'name'        => __( 'AI' ),
+				'name'        => __( 'Bad Quality (AI?)' ),
 				'explanation' => __( 'The translator has used some AI or other machine translation tool without additional manual review, and its quality is low.' ),
 			),
 		);


### PR DESCRIPTION
#### Problem

<!--
Please describe what is the status/problem before the PR.
-->

Some WordPress GTE have requested to add a new AI option to the "Give feedback" checkboxes.

![image](https://github.com/GlotPress/gp-translation-helpers/assets/1667814/7b15b977-047b-44f0-b4c8-69ec9139af26)

#### Solution

This PR adds this new checkbox.

![image](https://github.com/GlotPress/gp-translation-helpers/assets/1667814/4ec3ad34-9343-472a-879a-842f57575eb5)

When you use this checkbox (and, optionally, the comment)

![image](https://github.com/GlotPress/gp-translation-helpers/assets/1667814/b56c8f98-a86e-4333-8f9c-45a1935a6abb)

You get a new comment with the AI reason

![image](https://github.com/GlotPress/gp-translation-helpers/assets/1667814/7bbaaa1f-3f1d-4c84-ae9e-07032ebce4c3)


<!--
Please describe how this PR improves the situation.
-->

Fixes https://github.com/GlotPress/gp-translation-helpers/issues/214.
