### PR TITLE
Use a XHR link that has a trailing slash on it, to avoid 302's that eat into the request budget

### DIFF
--- a/includes/class-gp-translation-helpers.php
+++ b/includes/class-gp-translation-helpers.php
@@ -187,7 +187,7 @@ class GP_Translation_Helpers {
 		}
 
 		$translation_helpers_settings = array(
-			'th_url'   => gp_url_project( $args['project'], gp_url_join( $args['locale_slug'], $args['translation_set_slug'], '-get-translation-helpers' ) ),
+			'th_url'   => gp_url_project( $args['project'], gp_url_join( $args['locale_slug'], $args['translation_set_slug'], '-get-translation-helpers', '{ID}' ) ),
 			'ajax_url' => admin_url( 'admin-ajax.php' ),
 			'nonce'    => wp_create_nonce( 'gp_optin_optout' ),
 		);
@@ -424,7 +424,7 @@ class GP_Translation_Helpers {
 			'gp-translation-helpers-editor',
 			'$gp_translation_helpers_editor',
 			array(
-				'translation_helper_url' => gp_url_project( $translation_set['project']->path, gp_url_join( $translation_set['locale_slug'], $translation_set['translation_set']->slug, '-get-translation-helpers' ) ),
+				'translation_helper_url' => gp_url_project( $translation_set['project']->path, gp_url_join( $translation_set['locale_slug'], $translation_set['translation_set']->slug, '-get-translation-helpers', '{ID}' ) ),
 				'reply_text'             => esc_attr__( 'Reply' ),
 				'cancel_reply_text'      => esc_html__( 'Cancel reply' ),
 			)

--- a/js/editor.js
+++ b/js/editor.js
@@ -115,7 +115,7 @@ jQuery( function( $ ) {
 		const postId = $commentform.attr( 'id' ).split( '-' )[ 1 ];
 		const divDiscussion = $commentform.closest( '.meta.discussion' );
 		const rowId = divDiscussion.attr( 'data-row-id' );
-		const requestUrl = $gp_translation_helpers_editor.translation_helper_url + rowId + '?nohc';
+		const requestUrl = $gp_translation_helpers_editor.translation_helper_url.replace( '{ID}', rowId );
 
 		const submitComment = function( formdata ) {
 			$.ajax( {
@@ -278,7 +278,7 @@ jQuery( function( $ ) {
 	 */
 	function loadTabsAndDivs( element ) {
 		const rowId = element.closest( 'tr.editor' ).attr( 'id' ).substring( 7 );
-		const requestUrl = $gp_translation_helpers_editor.translation_helper_url + rowId + '?nohc';
+		const requestUrl = $gp_translation_helpers_editor.translation_helper_url.replace( '{ID}', rowId );
 		if ( translationHelpersCache[ rowId ] !== undefined ) {
 			updateDataInTabs( translationHelpersCache[ rowId ], rowId );
 		} else {
@@ -328,7 +328,7 @@ jQuery( function( $ ) {
 	 */
 	function cacheTranslationHelpersForARow( editor ) {
 		const rowId = editor.attr( 'row' );
-		const requestUrl = $gp_translation_helpers_editor.translation_helper_url + rowId + '?nohc';
+		const requestUrl = $gp_translation_helpers_editor.translation_helper_url.replace( '{ID}', rowId );
 		if ( ! rowId ) {
 			return;
 		}

--- a/js/translation-helpers.js
+++ b/js/translation-helpers.js
@@ -35,7 +35,7 @@ $gp.translation_helpers = (
 
 				const originalId = $helpers.parent().attr( 'row' ); // eslint-disable-line vars-on-top
 				const replytocom = $helpers.parent().attr( 'replytocom' ); // eslint-disable-line vars-on-top
-				var requestUrl = $gp_translation_helpers_settings.th_url + originalId + '?nohc'; // eslint-disable-line
+				let requestUrl = $gp_translation_helpers_settings.th_url.replace( '{ID}', originalId ) + '?';
 
 				if ( which ) {
 					requestUrl = requestUrl + '&helpers[]=' + which;


### PR DESCRIPTION
#### Problem

The GP Translation Helpers loads a non-slashed path, which is immediately redirected to the slashed variant by redirect_canonical().

Translate.wordpress.org has a low requests-per-second limit, and this results in double the number of XHR requests being made than required.

#### Solution

Use a slashed link.

Because of how the links are generated, I chose to use an interpolated template instead of simply adding `/` to the links.

I also removed the `?nohc` from the URLs as I couldn't see any reason for them - Other than that it allowed a specific use case to simply append with `&...` which is all I can imagine it was for.

#### Example:

**Before**
<img width="922" alt="Screenshot 2024-04-15 at 3 56 59 PM" src="https://github.com/GlotPress/gp-translation-helpers/assets/767313/56553b05-c0fe-46e9-9e57-1f9ade670b43">

**After**

<img width="922" alt="Screenshot 2024-04-15 at 4 04 22 PM" src="https://github.com/GlotPress/gp-translation-helpers/assets/767313/87cf9b8d-7379-4050-a920-dd4933af6bad">

