### PR TITLE
Resolve a bug when the user hides the "ChatGPT Review" element

### DIFF
--- a/js/editor.js
+++ b/js/editor.js
@@ -42,9 +42,7 @@ jQuery( function( $ ) {
 		}
 		if ( ! $gp_comment_feedback_settings.openai_key || ! $gp_editor_options.can_approve || ( 'waiting' !== translation_status && 'fuzzy' !== translation_status ) ) {
 			tr.find( '.details-chatgpt' ).hide();
-		} else if ( ! chatgpt_review_enabled ) {
-			tr.find( '.openai-review' ).hide();
-		} else {
+		} else if ( chatgpt_review_enabled ) {
 			fetchOpenAIReviewResponse( rowId, tr, false );
 		}
 	} );

--- a/js/editor.js
+++ b/js/editor.js
@@ -40,11 +40,12 @@ jQuery( function( $ ) {
 		if ( nextEditor.length ) {
 			cacheTranslationHelpersForARow( nextEditor );
 		}
-
-		if ( chatgpt_review_enabled && $gp_comment_feedback_settings.openai_key && $gp_editor_options.can_approve && ( 'waiting' === translation_status || 'fuzzy' === translation_status ) ) {
-			fetchOpenAIReviewResponse( rowId, tr, false );
+		if ( ! $gp_comment_feedback_settings.openai_key || ! $gp_editor_options.can_approve || ( 'waiting' !== translation_status && 'fuzzy' !== translation_status ) ) {
+			tr.find( '.details-chatgpt' ).hide();
+		} else if ( ! chatgpt_review_enabled ) {
+			tr.find( '.openai-review' ).hide();
 		} else {
-			tr.find( '.details-chatgpt, .openai-review' ).hide();
+			fetchOpenAIReviewResponse( rowId, tr, false );
 		}
 	} );
 


### PR DESCRIPTION
## Problem

<!--
Please describe what is the status/problem before the PR.
-->

When a user hides the "ChatGPT Review" element, next time she reloads the page and tries to see this element, it is hidden, due to an incorrect check. 

![image](https://github.com/GlotPress/gp-translation-helpers/assets/1667814/0430455e-988f-4879-b435-2c8d0f12d70f)

## Solution

This PR updates the logic to show the different elements:

- First check:
   - Checks if `openai_key` is not present.
   - Checks if the user cannot approve.
   - Checks if the translation status is neither `waiting` nor `fuzzy`.

If any of these conditions are true, "ChatGPT Review" is hidden (`.details-chatgpt`).

- Second check (If none of the previous conditions are true):
   - Checks if `chatgpt_review_enabled` is false. If this condition is true, only the "Review by ChatGPT" (`.openai-review`) element is hidden, not the "ChatGPT Review" title.
- Final else Block: If all conditions are met (i.e., `chatgpt_review_enabled` is true, we have `openai_key`, the user can approve, and the translation status is `waiting` or `fuzzy`), it proceeds to fetch the OpenAI review response.
<!--
Please describe how this PR improves the situation.
-->

## Testing instructions

In a project at translate.w.org (you can use the Emoji locale), filter the `waiting` strings:
1. In the first row, display the "ChatGPT Review" element. You should see the "Review by ChatGPT" element.
2. Go to the second row. The "ChatGPT Review" element should be displayed, and the "Review by ChatGPT" too.
3. Hide the "ChatGPT Review" element in the second row.
4. Go to the third row. The "ChatGPT Review" element should be displayed, but not the "Review by ChatGPT".
5. Reload the page. The "ChatGPT Review" element should be displayed, but not the "Review by ChatGPT".
6. In the same project, filter the `current` strings. Neither "ChatGPT Review" nor "Review by ChatGPT" should appear.
<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

