### PR TITLE
Do not uncheck the bulk checkboxes

### DIFF
--- a/js/reject-feedback.js
+++ b/js/reject-feedback.js
@@ -39,7 +39,6 @@
 								bulkTranslationStatus.push( translationStatus );
 								return selectedRow.attr( 'row' );
 							}
-							$( this ).prop( 'checked', false );
 							return null;
 						},
 					).get();


### PR DESCRIPTION
## Problem

When we process a bulk update, the selected checkboxes in the bulk form are deselected. This affects to another plugins, like the new [WPORG GP Bulk pre-translations](https://github.com/amieiro/wporg-gp-bulk-pretranslations) plugin.

<!--
Please describe what is the status/problem before the PR.
-->

## Solution

This PR removes this uncheck. I have manually tested it and doesn't affect the bulk rejection.

<!--
Please describe how this PR improves the situation.
-->

## Testing instructions

To test it, make some bulk approvals and rejections and you will see all works fine.
<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

